### PR TITLE
Add bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue--bug-report.md
+++ b/.github/ISSUE_TEMPLATE/issue--bug-report.md
@@ -1,0 +1,25 @@
+---
+name: 'Bug Report'
+about: Report a problem.
+title: "Bug: describe bug here"
+labels: Bug
+assignees: ''
+
+---
+
+*SECURITY NOTICE: If you think you’ve found a potential security issue, please do not post it in the Issues. Instead, please follow the instructions [here](https://aws.amazon.com/security/vulnerability-reporting/) or [email AWS security directly](mailto:aws-security@amazon.com).*
+
+**Summary**
+What are you observing that doesn't seem right?
+
+**Steps to Reproduce**
+What are the steps you can take to reproduce this issue?
+
+**Are you currently working around this issue?**
+How are you currently solving this problem?
+
+**Additional context**
+Anything else we should know?
+
+**Attachments**
+If you think you might have additional information that you'd like to include via an attachment, please do - we'll take a look. (Remember to remove any personally-identifiable information.)

--- a/.github/ISSUE_TEMPLATE/issue--community-request.md
+++ b/.github/ISSUE_TEMPLATE/issue--community-request.md
@@ -1,8 +1,7 @@
 ---
-name: 'Issue: Community Request'
-about: Suggest an idea for the roadmap! The team will review. If this doesn’t look
-  right, choose a different type.
-title: "[request]: describe request here"
+name: 'Feature Request'
+about: Suggest an idea for the roadmap!
+title: "Feature Request: describe request here"
 labels: Proposed
 assignees: ''
 
@@ -18,7 +17,7 @@ This could be Fargate, ECS, EKS, EC2, Kubernetes, something else.
 What outcome are you trying to achieve, ultimately, and why is it hard/impossible to do right now? What is the impact of not having this problem solved? The more details you can provide, the better we'll be able to understand and solve the problem.
 
 **Are you currently working around this issue?**
-How are you currently solving this problem? 
+How are you currently solving this problem?
 
 **Additional context**
 Anything else we should know?


### PR DESCRIPTION
I'd like to propose we split our current issue template into two types: feature requests and bug reports. I think this will help disambiguate the information we need to know for certain types of issues created on the roadmap.
