### PR TITLE
Add slack community, make beta channel not new

### DIFF
--- a/BETA-CHANNEL.md
+++ b/BETA-CHANNEL.md
@@ -2,7 +2,7 @@
 
 ## What are we announcing?
 
-The AWS App Mesh service team is announcing the upcoming availability of a Beta Channel, a new public service endpoint which allows every customer to try out and provide feedback on beta service features before they are generally available. This new service endpoint will be separate from the standard production endpoint, and will be coupled with beta releases of the AWS CLI for App Mesh, allowing customers to test beta features without impacting their current production infrastructure.
+The AWS App Mesh service team is announcing the availability of a Beta Channel, a new public service endpoint which allows every customer to try out and provide feedback on beta service features before they are generally available. This new service endpoint is separate from the standard production endpoint, and is coupled with beta releases of the AWS CLI for App Mesh, allowing customers to test beta features without impacting their current production infrastructure.
 
 ## What do I get from the Beta Channel?
 
@@ -10,12 +10,11 @@ With the Beta Channel, you get the opportunity to try out features before we mak
 
 ## How can I on-board?
 
-The Beta Channel will be available to all existing AWS customers. To on-board to the new endpoint, you can download beta versions of the AWS CLI JSON configuration for App Mesh. These beta versions will be made available via GitHub issues on the [AWS App Mesh public roadmap](https://github.com/aws/aws-app-mesh-roadmap).
+The Beta Channel is available to all existing AWS customers. To on-board to the new endpoint, you can download the latest beta version of the AWS CLI JSON configuration for App Mesh [here](https://github.com/aws/aws-app-mesh-roadmap/tree/master/appmesh-preview).
 
 In the future we may release beta SDKs for all languages.
 
-To preview upcoming features for AWS App Mesh and get information on how you can test and provide feedback, check out our [AWS App Mesh public roadmap](https://github.com/aws/aws-app-mesh-roadmap) on GitHub. Beta features will listed in our GitHub issues page with a “Beta” label.
-
+To preview upcoming features for AWS App Mesh and get information on how you can test and provide feedback, check out our [AWS App Mesh public roadmap](https://github.com/aws/aws-app-mesh-roadmap) on GitHub. Beta features are listed in our GitHub issues page with a ["Phase: In Preview" label](https://github.com/aws/aws-app-mesh-roadmap/issues?q=is%3Aissue+is%3Aopen+label%3A%22Phase%3A+In+Preview%22+).
 
 ## How long do I have to provide feedback on a preview feature?
 
@@ -32,7 +31,3 @@ Yes. The AWS App Mesh beta endpoint is given the same level of security as the s
 ## Is my data durable on the beta endpoint?
 
 Due to the desire of getting features in the hands of customers early for feedback, AWS App Mesh does not guarantee the durability of customer data provided to the beta endpoint. We may, from time to time, reset the data store behind the preview endpoint to guarantee the best long-term customer experience. Before this occurs, the AWS App Mesh team will announce the reset and provide time and guidance for you to save your existing resources so they can be replaced once the reset has completed. Long-term, we will invest in open-source tooling to help you migrate your production resources to the beta endpoint.
-
-## When will the Beta Channel be available?
-
-Coming soon.  Details will be posted here as they become available.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,14 @@ Knowing about our upcoming products and priorities helps our customers plan. Thi
 [See the roadmap »](https://github.com/aws/aws-app-mesh-roadmap/projects/1)
 
 ## Beta Channel
-The App Mesh team recently announced the upcoming availability of a Beta Channel, a new public service endpoint which allows every customer to try out and provide feedback on beta service features before they are generally available. This new service endpoint will be separate from the standard production endpoint, and will be coupled with preview releases of the AWS CLI for App Mesh, allowing customers to test beta features without impacting their current production infrastructure.
+AWS App Mesh offers a Beta Channel, a public service endpoint which allows every customer to try out and provide feedback on beta service features before they are generally available. The service endpoint is separate from the standard production endpoint, and is coupled with preview releases of the AWS CLI for App Mesh, allowing customers to test beta features without impacting their current production infrastructure.
 
 For more information on the Beta Channel, see [AWS App Mesh Beta Channel](/BETA-CHANNEL.md).
+
+## Slack Community
+AWS App Mesh participates in an open Slack community in which participants can share tips and tricks, get help troubleshooting a problem, or discuss new and potential future features of App Mesh.
+
+The slack community can be found at https://awsappmesh.slack.com, and you can join the slack community with [this invite](https://join.slack.com/t/awsappmesh/shared_invite/zt-dwgbt85c-Sj_md92__quV8YADKfsQSA).
 
 ## Security disclosures
 


### PR DESCRIPTION
*Issue #, if available:* #139 

*Description of changes:*

1. Add information on how to join the App Mesh slack community.
2. Clarify that the beta channel is available now with some additional instructions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
