### PR TITLE
Add preview SDK models

### DIFF
--- a/appmesh-preview/sdk/README.md
+++ b/appmesh-preview/sdk/README.md
@@ -1,0 +1,84 @@
+# App Mesh Preview SDKs
+
+Some AWS SDKs use a set of JSON models to generate the final SDK. SDKs which allow this include:
+
+* [Go](https://github.com/aws/aws-sdk-go)
+* [JavaScript](https://github.com/aws/aws-sdk-js)
+* [Ruby](https://github.com/aws/aws-sdk-ruby/)
+
+For these SDKs, you can use the JSON files in this directory to generate an SDK which can be used for the [App Mesh Preview Channel](https://docs.aws.amazon.com/app-mesh/latest/userguide/preview.html).
+
+## Generating an SDK
+
+### Go
+
+Clone the AWS SDK for Go:
+
+```bash
+git clone https://github.com/aws/aws-sdk-go.git
+cd aws-sdk-go
+```
+
+Download the JSON files, replacing the appropriate files in the SDK:
+
+```bash
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/api.json > models/apis/appmesh/2019-01-25/api-2.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/docs.json > models/apis/appmesh/2019-01-25/docs-2.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/examples.json > models/apis/appmesh/2019-01-25/examples-1.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/paginators.json > models/apis/appmesh/2019-01-25/paginators-1.json
+```
+
+Generate the SDK:
+
+```bash
+make generate
+```
+
+### JavaScript
+
+Clone the AWS SDK for JavaScript:
+
+```bash
+git clone https://github.com/aws/aws-sdk-js.git
+cd aws-sdk-js
+```
+
+Download the JSON files, replacing the appropriate files in the SDK:
+
+```bash
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/api.json > apis/appmesh-2019-01-25.min.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/api.normal.json > apis/appmesh-2019-01-25.normal.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/examples.json > apis/appmesh-2019-01-25.examples.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/paginators.json > apis/appmesh-2019-01-25.paginators.json
+```
+
+Generate the SDK:
+
+```bash
+rake api
+```
+
+### Ruby
+
+Clone the AWS SDK for Ruby:
+
+```bash
+git clone https://github.com/aws/aws-sdk-ruby.git
+cd aws-sdk-ruby
+```
+
+Download the JSON files, replacing the appropriate files in the SDK:
+
+```bash
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/api.json > apis/appmesh/2019-01-25/api-2.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/docs.json > apis/appmesh/2019-01-25/docs-2.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/examples.json > apis/appmesh/2019-01-25/examples-1.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/paginators.json > apis/appmesh/2019-01-25/paginators-1.json
+```
+
+Generate the SDK:
+
+```bash
+bundle install
+rake build
+```

--- a/appmesh-preview/sdk/api.json
+++ b/appmesh-preview/sdk/api.json
@@ -1,0 +1,5055 @@
+{
+  "version": "2.0",
+  "metadata": {
+    "apiVersion": "2019-01-25",
+    "endpointPrefix": "appmesh-preview",
+    "jsonVersion": "1.1",
+    "protocol": "rest-json",
+    "serviceFullName": "AWS App Mesh Preview",
+    "serviceId": "App Mesh Preview",
+    "signatureVersion": "v4",
+    "signingName": "appmesh-preview",
+    "uid": "appmesh-preview-2019-01-25"
+  },
+  "operations": {
+    "CreateGatewayRoute": {
+      "name": "CreateGatewayRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateGatewayRouteInput"
+      },
+      "output": {
+        "shape": "CreateGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateMesh": {
+      "name": "CreateMesh",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateMeshInput"
+      },
+      "output": {
+        "shape": "CreateMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateRoute": {
+      "name": "CreateRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateRouteInput"
+      },
+      "output": {
+        "shape": "CreateRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateVirtualGateway": {
+      "name": "CreateVirtualGateway",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "CreateVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateVirtualNode": {
+      "name": "CreateVirtualNode",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualNodeInput"
+      },
+      "output": {
+        "shape": "CreateVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateVirtualRouter": {
+      "name": "CreateVirtualRouter",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualRouterInput"
+      },
+      "output": {
+        "shape": "CreateVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateVirtualService": {
+      "name": "CreateVirtualService",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualServiceInput"
+      },
+      "output": {
+        "shape": "CreateVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteGatewayRoute": {
+      "name": "DeleteGatewayRoute",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes/{gatewayRouteName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteGatewayRouteInput"
+      },
+      "output": {
+        "shape": "DeleteGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteMesh": {
+      "name": "DeleteMesh",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteMeshInput"
+      },
+      "output": {
+        "shape": "DeleteMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteRoute": {
+      "name": "DeleteRoute",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteRouteInput"
+      },
+      "output": {
+        "shape": "DeleteRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteVirtualGateway": {
+      "name": "DeleteVirtualGateway",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways/{virtualGatewayName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteVirtualNode": {
+      "name": "DeleteVirtualNode",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualNodeInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteVirtualRouter": {
+      "name": "DeleteVirtualRouter",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualRouterInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteVirtualService": {
+      "name": "DeleteVirtualService",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualServiceInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DescribeGatewayRoute": {
+      "name": "DescribeGatewayRoute",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes/{gatewayRouteName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeGatewayRouteInput"
+      },
+      "output": {
+        "shape": "DescribeGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeMesh": {
+      "name": "DescribeMesh",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeMeshInput"
+      },
+      "output": {
+        "shape": "DescribeMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeRoute": {
+      "name": "DescribeRoute",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeRouteInput"
+      },
+      "output": {
+        "shape": "DescribeRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeVirtualGateway": {
+      "name": "DescribeVirtualGateway",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways/{virtualGatewayName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeVirtualNode": {
+      "name": "DescribeVirtualNode",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualNodeInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeVirtualRouter": {
+      "name": "DescribeVirtualRouter",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualRouterInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeVirtualService": {
+      "name": "DescribeVirtualService",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualServiceInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListGatewayRoutes": {
+      "name": "ListGatewayRoutes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListGatewayRoutesInput"
+      },
+      "output": {
+        "shape": "ListGatewayRoutesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListMeshes": {
+      "name": "ListMeshes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListMeshesInput"
+      },
+      "output": {
+        "shape": "ListMeshesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListRoutes": {
+      "name": "ListRoutes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListRoutesInput"
+      },
+      "output": {
+        "shape": "ListRoutesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListVirtualGateways": {
+      "name": "ListVirtualGateways",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualGatewaysInput"
+      },
+      "output": {
+        "shape": "ListVirtualGatewaysOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListVirtualNodes": {
+      "name": "ListVirtualNodes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualNodesInput"
+      },
+      "output": {
+        "shape": "ListVirtualNodesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListVirtualRouters": {
+      "name": "ListVirtualRouters",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualRoutersInput"
+      },
+      "output": {
+        "shape": "ListVirtualRoutersOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListVirtualServices": {
+      "name": "ListVirtualServices",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualServicesInput"
+      },
+      "output": {
+        "shape": "ListVirtualServicesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "UpdateGatewayRoute": {
+      "name": "UpdateGatewayRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes/{gatewayRouteName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateGatewayRouteInput"
+      },
+      "output": {
+        "shape": "UpdateGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateMesh": {
+      "name": "UpdateMesh",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateMeshInput"
+      },
+      "output": {
+        "shape": "UpdateMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateRoute": {
+      "name": "UpdateRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateRouteInput"
+      },
+      "output": {
+        "shape": "UpdateRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateVirtualGateway": {
+      "name": "UpdateVirtualGateway",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways/{virtualGatewayName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateVirtualNode": {
+      "name": "UpdateVirtualNode",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualNodeInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateVirtualRouter": {
+      "name": "UpdateVirtualRouter",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualRouterInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateVirtualService": {
+      "name": "UpdateVirtualService",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualServiceInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    }
+  },
+  "shapes": {
+    "VirtualRouterListener": {
+      "type": "structure",
+      "required": [
+        "portMapping"
+      ],
+      "members": {
+        "portMapping": {
+          "shape": "PortMapping"
+        }
+      }
+    },
+    "VirtualRouterStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "GrpcRetryPolicy": {
+      "type": "structure",
+      "required": [
+        "maxRetries",
+        "perRetryTimeout"
+      ],
+      "members": {
+        "grpcRetryEvents": {
+          "shape": "GrpcRetryPolicyEvents"
+        },
+        "httpRetryEvents": {
+          "shape": "HttpRetryPolicyEvents"
+        },
+        "maxRetries": {
+          "shape": "MaxRetries"
+        },
+        "perRetryTimeout": {
+          "shape": "Duration"
+        },
+        "tcpRetryEvents": {
+          "shape": "TcpRetryPolicyEvents"
+        }
+      }
+    },
+    "CreateVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData"
+        }
+      },
+      "payload": "virtualNode"
+    },
+    "Logging": {
+      "type": "structure",
+      "members": {
+        "accessLog": {
+          "shape": "AccessLog"
+        }
+      }
+    },
+    "Long": {
+      "type": "long",
+      "box": true
+    },
+    "UpdateVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData"
+        }
+      },
+      "payload": "virtualRouter"
+    },
+    "ListVirtualRoutersOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouters"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "virtualRouters": {
+          "shape": "VirtualRouterList"
+        }
+      }
+    },
+    "CreateVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualGatewaySpec"
+        },
+        "tags": {
+          "shape": "TagList"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "UpdateVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualGatewaySpec"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "ResourceMetadata": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshOwner",
+        "resourceOwner",
+        "uid",
+        "version"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "uid": {
+          "shape": "String"
+        },
+        "version": {
+          "shape": "Long"
+        }
+      }
+    },
+    "ResourceInUseException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "ResourceInUseException",
+        "httpStatusCode": 409,
+        "senderFault": true
+      }
+    },
+    "UpdateVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData"
+        }
+      },
+      "payload": "virtualNode"
+    },
+    "ListRoutesOutput": {
+      "type": "structure",
+      "required": [
+        "routes"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "routes": {
+          "shape": "RouteList"
+        }
+      }
+    },
+    "VirtualServiceBackend": {
+      "type": "structure",
+      "required": [
+        "virtualServiceName"
+      ],
+      "members": {
+        "clientPolicy": {
+          "shape": "ClientPolicy"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "BadRequestException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "BadRequestException",
+        "httpStatusCode": 400,
+        "senderFault": true
+      }
+    },
+    "HttpGatewayRouteMatch": {
+      "type": "structure",
+      "required": [
+        "prefix"
+      ],
+      "members": {
+        "prefix": {
+          "shape": "String"
+        }
+      }
+    },
+    "GrpcRouteMetadataList": {
+      "type": "list",
+      "member": {
+        "shape": "GrpcRouteMetadata"
+      },
+      "min": 1,
+      "max": 10
+    },
+    "ListenerTlsMode": {
+      "type": "string",
+      "enum": [
+        "DISABLED",
+        "PERMISSIVE",
+        "STRICT"
+      ]
+    },
+    "HealthCheckPolicy": {
+      "type": "structure",
+      "required": [
+        "healthyThreshold",
+        "intervalMillis",
+        "protocol",
+        "timeoutMillis",
+        "unhealthyThreshold"
+      ],
+      "members": {
+        "healthyThreshold": {
+          "shape": "HealthCheckThreshold"
+        },
+        "intervalMillis": {
+          "shape": "HealthCheckIntervalMillis"
+        },
+        "path": {
+          "shape": "String"
+        },
+        "port": {
+          "shape": "PortNumber"
+        },
+        "protocol": {
+          "shape": "PortProtocol"
+        },
+        "timeoutMillis": {
+          "shape": "HealthCheckTimeoutMillis"
+        },
+        "unhealthyThreshold": {
+          "shape": "HealthCheckThreshold"
+        }
+      }
+    },
+    "VirtualGatewayHealthCheckTimeoutMillis": {
+      "type": "long",
+      "box": true,
+      "min": 2000,
+      "max": 60000
+    },
+    "EgressFilter": {
+      "type": "structure",
+      "required": [
+        "type"
+      ],
+      "members": {
+        "type": {
+          "shape": "EgressFilterType"
+        }
+      }
+    },
+    "VirtualServiceList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualServiceRef"
+      }
+    },
+    "ClientPolicy": {
+      "type": "structure",
+      "members": {
+        "tls": {
+          "shape": "ClientPolicyTls"
+        }
+      }
+    },
+    "VirtualGatewayHealthCheckIntervalMillis": {
+      "type": "long",
+      "box": true,
+      "min": 5000,
+      "max": 300000
+    },
+    "Boolean": {
+      "type": "boolean",
+      "box": true
+    },
+    "VirtualGatewaySpec": {
+      "type": "structure",
+      "required": [
+        "listeners"
+      ],
+      "members": {
+        "backendDefaults": {
+          "shape": "VirtualGatewayBackendDefaults"
+        },
+        "listeners": {
+          "shape": "VirtualGatewayListeners"
+        }
+      }
+    },
+    "HttpRetryPolicyEvent": {
+      "type": "string",
+      "min": 1,
+      "max": 25
+    },
+    "VirtualGatewayFileAccessLog": {
+      "type": "structure",
+      "required": [
+        "path"
+      ],
+      "members": {
+        "path": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "DescribeVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData"
+        }
+      },
+      "payload": "virtualService"
+    },
+    "CreateGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "gatewayRouteName": {
+          "shape": "ResourceName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "GatewayRouteSpec"
+        },
+        "tags": {
+          "shape": "TagList"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "CertificateAuthorityArns": {
+      "type": "list",
+      "member": {
+        "shape": "Arn"
+      },
+      "min": 1,
+      "max": 3
+    },
+    "DescribeVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData"
+        }
+      },
+      "payload": "virtualNode"
+    },
+    "AwsCloudMapName": {
+      "type": "string",
+      "min": 1,
+      "max": 1024,
+      "pattern": "((?=^.{1,127}$)^([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9])(.([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9]))*$)|(^.$)"
+    },
+    "VirtualGatewayData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "VirtualGatewaySpec"
+        },
+        "status": {
+          "shape": "VirtualGatewayStatus"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "CreateRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData"
+        }
+      },
+      "payload": "route"
+    },
+    "VirtualGatewayListener": {
+      "type": "structure",
+      "required": [
+        "portMapping"
+      ],
+      "members": {
+        "healthCheck": {
+          "shape": "VirtualGatewayHealthCheckPolicy"
+        },
+        "logging": {
+          "shape": "VirtualGatewayLogging"
+        },
+        "portMapping": {
+          "shape": "VirtualGatewayPortMapping"
+        },
+        "tls": {
+          "shape": "VirtualGatewayListenerTls"
+        }
+      }
+    },
+    "DnsServiceDiscovery": {
+      "type": "structure",
+      "required": [
+        "hostname"
+      ],
+      "members": {
+        "hostname": {
+          "shape": "Hostname"
+        }
+      }
+    },
+    "VirtualGatewayPortMapping": {
+      "type": "structure",
+      "required": [
+        "port",
+        "protocol"
+      ],
+      "members": {
+        "port": {
+          "shape": "PortNumber"
+        },
+        "protocol": {
+          "shape": "VirtualGatewayPortProtocol"
+        }
+      }
+    },
+    "DeleteVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "DeleteRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "routeName"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "VirtualNodeData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualNodeName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "VirtualNodeSpec"
+        },
+        "status": {
+          "shape": "VirtualNodeStatus"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "ListGatewayRoutesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "TcpRetryPolicyEvent": {
+      "type": "string",
+      "enum": [
+        "connection-error"
+      ]
+    },
+    "VirtualGatewayListenerTls": {
+      "type": "structure",
+      "required": [
+        "certificate",
+        "mode"
+      ],
+      "members": {
+        "certificate": {
+          "shape": "VirtualGatewayListenerTlsCertificate"
+        },
+        "mode": {
+          "shape": "VirtualGatewayListenerTlsMode"
+        }
+      }
+    },
+    "Backend": {
+      "type": "structure",
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceBackend"
+        }
+      }
+    },
+    "ListMeshesInput": {
+      "type": "structure",
+      "members": {
+        "limit": {
+          "shape": "ListMeshesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "VirtualGatewayListenerTlsFileCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateChain",
+        "privateKey"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath"
+        },
+        "privateKey": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "ListGatewayRoutesInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListGatewayRoutesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "VirtualRouterData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "VirtualRouterSpec"
+        },
+        "status": {
+          "shape": "VirtualRouterStatus"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "UpdateMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "spec": {
+          "shape": "MeshSpec"
+        }
+      }
+    },
+    "VirtualGatewayHealthCheckPolicy": {
+      "type": "structure",
+      "required": [
+        "healthyThreshold",
+        "intervalMillis",
+        "protocol",
+        "timeoutMillis",
+        "unhealthyThreshold"
+      ],
+      "members": {
+        "healthyThreshold": {
+          "shape": "VirtualGatewayHealthCheckThreshold"
+        },
+        "intervalMillis": {
+          "shape": "VirtualGatewayHealthCheckIntervalMillis"
+        },
+        "path": {
+          "shape": "String"
+        },
+        "port": {
+          "shape": "PortNumber"
+        },
+        "protocol": {
+          "shape": "VirtualGatewayPortProtocol"
+        },
+        "timeoutMillis": {
+          "shape": "VirtualGatewayHealthCheckTimeoutMillis"
+        },
+        "unhealthyThreshold": {
+          "shape": "VirtualGatewayHealthCheckThreshold"
+        }
+      }
+    },
+    "CreateVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualRouterSpec"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "DescribeVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData"
+        }
+      },
+      "payload": "virtualRouter"
+    },
+    "CreateMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData"
+        }
+      },
+      "payload": "mesh"
+    },
+    "CreateVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData"
+        }
+      },
+      "payload": "virtualRouter"
+    },
+    "VirtualServiceStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualServiceStatusCode"
+        }
+      }
+    },
+    "HttpRetryPolicyEvents": {
+      "type": "list",
+      "member": {
+        "shape": "HttpRetryPolicyEvent"
+      },
+      "min": 1,
+      "max": 25
+    },
+    "VirtualGatewayListenerTlsCertificate": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "VirtualGatewayListenerTlsAcmCertificate"
+        },
+        "file": {
+          "shape": "VirtualGatewayListenerTlsFileCertificate"
+        }
+      }
+    },
+    "ListenerTlsCertificate": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "ListenerTlsAcmCertificate"
+        },
+        "file": {
+          "shape": "ListenerTlsFileCertificate"
+        }
+      }
+    },
+    "ListMeshesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "AwsCloudMapInstanceAttributeKey": {
+      "type": "string",
+      "min": 1,
+      "max": 255,
+      "pattern": "^[a-zA-Z0-9!-~]+$"
+    },
+    "VirtualRouterSpec": {
+      "type": "structure",
+      "members": {
+        "listeners": {
+          "shape": "VirtualRouterListeners"
+        }
+      }
+    },
+    "GatewayRouteVirtualService": {
+      "type": "structure",
+      "required": [
+        "virtualServiceName"
+      ],
+      "members": {
+        "virtualServiceName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "VirtualNodeSpec": {
+      "type": "structure",
+      "members": {
+        "backendDefaults": {
+          "shape": "BackendDefaults"
+        },
+        "backends": {
+          "shape": "Backends"
+        },
+        "listeners": {
+          "shape": "Listeners"
+        },
+        "logging": {
+          "shape": "Logging"
+        },
+        "serviceDiscovery": {
+          "shape": "ServiceDiscovery"
+        }
+      }
+    },
+    "ListMeshesOutput": {
+      "type": "structure",
+      "required": [
+        "meshes"
+      ],
+      "members": {
+        "meshes": {
+          "shape": "MeshList"
+        },
+        "nextToken": {
+          "shape": "String"
+        }
+      }
+    },
+    "VirtualRouterListeners": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualRouterListener"
+      },
+      "min": 1,
+      "max": 1
+    },
+    "GatewayRouteSpec": {
+      "type": "structure",
+      "members": {
+        "grpcRoute": {
+          "shape": "GrpcGatewayRoute"
+        },
+        "http2Route": {
+          "shape": "HttpGatewayRoute"
+        },
+        "httpRoute": {
+          "shape": "HttpGatewayRoute"
+        }
+      }
+    },
+    "PortSet": {
+      "type": "list",
+      "member": {
+        "shape": "PortNumber"
+      }
+    },
+    "HttpMethod": {
+      "type": "string",
+      "enum": [
+        "CONNECT",
+        "DELETE",
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "PUT",
+        "TRACE"
+      ]
+    },
+    "ConflictException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "ConflictException",
+        "httpStatusCode": 409,
+        "senderFault": true
+      }
+    },
+    "VirtualGatewayBackendDefaults": {
+      "type": "structure",
+      "members": {
+        "clientPolicy": {
+          "shape": "VirtualGatewayClientPolicy"
+        }
+      }
+    },
+    "ListenerTimeout": {
+      "type": "structure",
+      "members": {
+        "grpc": {
+          "shape": "GrpcTimeout"
+        },
+        "http": {
+          "shape": "HttpTimeout"
+        },
+        "http2": {
+          "shape": "HttpTimeout"
+        },
+        "tcp": {
+          "shape": "TcpTimeout"
+        }
+      }
+    },
+    "MeshList": {
+      "type": "list",
+      "member": {
+        "shape": "MeshRef"
+      }
+    },
+    "MaxRetries": {
+      "type": "long",
+      "box": true,
+      "min": 0
+    },
+    "DescribeGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "gatewayRouteName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "gatewayRouteName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "TlsValidationContextTrust": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "TlsValidationContextAcmTrust"
+        },
+        "file": {
+          "shape": "TlsValidationContextFileTrust"
+        }
+      }
+    },
+    "PortMapping": {
+      "type": "structure",
+      "required": [
+        "port",
+        "protocol"
+      ],
+      "members": {
+        "port": {
+          "shape": "PortNumber"
+        },
+        "protocol": {
+          "shape": "PortProtocol"
+        }
+      }
+    },
+    "VirtualGatewayHealthCheckThreshold": {
+      "type": "integer",
+      "min": 2,
+      "max": 10
+    },
+    "ListVirtualServicesOutput": {
+      "type": "structure",
+      "required": [
+        "virtualServices"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "virtualServices": {
+          "shape": "VirtualServiceList"
+        }
+      }
+    },
+    "AwsCloudMapInstanceAttributeValue": {
+      "type": "string",
+      "min": 1,
+      "max": 1024,
+      "pattern": "^([a-zA-Z0-9!-~][ ta-zA-Z0-9!-~]*){0,1}[a-zA-Z0-9!-~]{0,1}$"
+    },
+    "WeightedTarget": {
+      "type": "structure",
+      "required": [
+        "virtualNode",
+        "weight"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "ResourceName"
+        },
+        "weight": {
+          "shape": "PercentInt"
+        }
+      }
+    },
+    "GrpcGatewayRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "GrpcGatewayRouteAction"
+        },
+        "match": {
+          "shape": "GrpcGatewayRouteMatch"
+        }
+      }
+    },
+    "GatewayRouteData": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "gatewayRouteName": {
+          "shape": "ResourceName"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "GatewayRouteSpec"
+        },
+        "status": {
+          "shape": "GatewayRouteStatus"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "RouteRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "routeName",
+        "version",
+        "virtualRouterName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "routeName": {
+          "shape": "ResourceName"
+        },
+        "version": {
+          "shape": "Long"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "DeleteVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualNodeName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualNodeName"
+        }
+      }
+    },
+    "RouteData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "routeName",
+        "spec",
+        "status",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "routeName": {
+          "shape": "ResourceName"
+        },
+        "spec": {
+          "shape": "RouteSpec"
+        },
+        "status": {
+          "shape": "RouteStatus"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "RouteStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "InternalServerErrorException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "InternalServerErrorException",
+        "httpStatusCode": 500,
+        "fault": true
+      }
+    },
+    "HeaderName": {
+      "type": "string",
+      "min": 1,
+      "max": 50
+    },
+    "TagList": {
+      "type": "list",
+      "member": {
+        "shape": "TagRef"
+      },
+      "min": 0,
+      "max": 50
+    },
+    "GrpcRetryPolicyEvent": {
+      "type": "string",
+      "enum": [
+        "cancelled",
+        "deadline-exceeded",
+        "internal",
+        "resource-exhausted",
+        "unavailable"
+      ]
+    },
+    "TlsValidationContextAcmTrust": {
+      "type": "structure",
+      "required": [
+        "certificateAuthorityArns"
+      ],
+      "members": {
+        "certificateAuthorityArns": {
+          "shape": "CertificateAuthorityArns"
+        }
+      }
+    },
+    "ForbiddenException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "ForbiddenException",
+        "httpStatusCode": 403,
+        "senderFault": true
+      }
+    },
+    "HeaderMatchMethod": {
+      "type": "structure",
+      "members": {
+        "exact": {
+          "shape": "HeaderMatch"
+        },
+        "prefix": {
+          "shape": "HeaderMatch"
+        },
+        "range": {
+          "shape": "MatchRange"
+        },
+        "regex": {
+          "shape": "HeaderMatch"
+        },
+        "suffix": {
+          "shape": "HeaderMatch"
+        }
+      }
+    },
+    "DeleteMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData"
+        }
+      },
+      "payload": "mesh"
+    },
+    "VirtualGatewayClientPolicyTls": {
+      "type": "structure",
+      "required": [
+        "validation"
+      ],
+      "members": {
+        "enforce": {
+          "shape": "Boolean",
+          "box": true
+        },
+        "ports": {
+          "shape": "PortSet"
+        },
+        "validation": {
+          "shape": "VirtualGatewayTlsValidationContext"
+        }
+      }
+    },
+    "EgressFilterType": {
+      "type": "string",
+      "enum": [
+        "ALLOW_ALL",
+        "DROP_ALL"
+      ]
+    },
+    "DurationValue": {
+      "type": "long",
+      "box": true,
+      "min": 0
+    },
+    "Hostname": {
+      "type": "string"
+    },
+    "VirtualGatewayStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualGatewayStatusCode"
+        }
+      }
+    },
+    "GatewayRouteStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "GatewayRouteStatusCode"
+        }
+      }
+    },
+    "VirtualGatewayListeners": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualGatewayListener"
+      },
+      "min": 0,
+      "max": 1
+    },
+    "CreateVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "ListVirtualGatewaysOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateways"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "virtualGateways": {
+          "shape": "VirtualGatewayList"
+        }
+      }
+    },
+    "VirtualGatewayTlsValidationContext": {
+      "type": "structure",
+      "required": [
+        "trust"
+      ],
+      "members": {
+        "trust": {
+          "shape": "VirtualGatewayTlsValidationContextTrust"
+        }
+      }
+    },
+    "VirtualServiceProvider": {
+      "type": "structure",
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeServiceProvider"
+        },
+        "virtualRouter": {
+          "shape": "VirtualRouterServiceProvider"
+        }
+      }
+    },
+    "GrpcRouteMatch": {
+      "type": "structure",
+      "members": {
+        "metadata": {
+          "shape": "GrpcRouteMetadataList"
+        },
+        "methodName": {
+          "shape": "MethodName"
+        },
+        "serviceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "AwsCloudMapServiceDiscovery": {
+      "type": "structure",
+      "required": [
+        "namespaceName",
+        "serviceName"
+      ],
+      "members": {
+        "attributes": {
+          "shape": "AwsCloudMapInstanceAttributes"
+        },
+        "namespaceName": {
+          "shape": "AwsCloudMapName"
+        },
+        "serviceName": {
+          "shape": "AwsCloudMapName"
+        }
+      }
+    },
+    "UpdateVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData"
+        }
+      },
+      "payload": "virtualService"
+    },
+    "MeshStatus": {
+      "type": "structure",
+      "members": {
+        "status": {
+          "shape": "MeshStatusCode"
+        }
+      }
+    },
+    "CreateVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualNodeName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualNodeSpec"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "NotFoundException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "NotFoundException",
+        "httpStatusCode": 404,
+        "senderFault": true
+      }
+    },
+    "RouteSpec": {
+      "type": "structure",
+      "members": {
+        "grpcRoute": {
+          "shape": "GrpcRoute"
+        },
+        "http2Route": {
+          "shape": "HttpRoute"
+        },
+        "httpRoute": {
+          "shape": "HttpRoute"
+        },
+        "priority": {
+          "shape": "RoutePriority"
+        },
+        "tcpRoute": {
+          "shape": "TcpRoute"
+        }
+      }
+    },
+    "GatewayRouteRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "gatewayRouteName",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "gatewayRouteName": {
+          "shape": "ResourceName"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "VirtualGatewayListenerTlsAcmCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateArn"
+      ],
+      "members": {
+        "certificateArn": {
+          "shape": "Arn"
+        }
+      }
+    },
+    "ListGatewayRoutesOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoutes"
+      ],
+      "members": {
+        "gatewayRoutes": {
+          "shape": "GatewayRouteList"
+        },
+        "nextToken": {
+          "shape": "String"
+        }
+      }
+    },
+    "CreateVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData"
+        }
+      },
+      "payload": "virtualService"
+    },
+    "FileAccessLog": {
+      "type": "structure",
+      "required": [
+        "path"
+      ],
+      "members": {
+        "path": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "VirtualRouterServiceProvider": {
+      "type": "structure",
+      "required": [
+        "virtualRouterName"
+      ],
+      "members": {
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "HttpTimeout": {
+      "type": "structure",
+      "members": {
+        "idle": {
+          "shape": "Duration"
+        },
+        "perRequest": {
+          "shape": "Duration"
+        }
+      }
+    },
+    "DeleteVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualServiceName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "location": "uri",
+          "locationName": "virtualServiceName"
+        }
+      }
+    },
+    "TlsValidationContext": {
+      "type": "structure",
+      "required": [
+        "trust"
+      ],
+      "members": {
+        "trust": {
+          "shape": "TlsValidationContextTrust"
+        }
+      }
+    },
+    "GatewayRouteStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "DeleteVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData"
+        }
+      },
+      "payload": "virtualRouter"
+    },
+    "DescribeVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "GrpcGatewayRouteAction": {
+      "type": "structure",
+      "required": [
+        "target"
+      ],
+      "members": {
+        "target": {
+          "shape": "GatewayRouteTarget"
+        }
+      }
+    },
+    "DeleteVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData"
+        }
+      },
+      "payload": "virtualNode"
+    },
+    "UpdateVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualNodeName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualNodeSpec"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualNodeName"
+        }
+      }
+    },
+    "ListenerTls": {
+      "type": "structure",
+      "required": [
+        "certificate",
+        "mode"
+      ],
+      "members": {
+        "certificate": {
+          "shape": "ListenerTlsCertificate"
+        },
+        "mode": {
+          "shape": "ListenerTlsMode"
+        }
+      }
+    },
+    "DeleteMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        }
+      }
+    },
+    "TcpRetryPolicyEvents": {
+      "type": "list",
+      "member": {
+        "shape": "TcpRetryPolicyEvent"
+      },
+      "min": 1,
+      "max": 1
+    },
+    "CreateVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualServiceName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualServiceSpec"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "UpdateVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualRouterSpec"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "HttpGatewayRouteAction": {
+      "type": "structure",
+      "required": [
+        "target"
+      ],
+      "members": {
+        "target": {
+          "shape": "GatewayRouteTarget"
+        }
+      }
+    },
+    "GrpcGatewayRouteMatch": {
+      "type": "structure",
+      "members": {
+        "serviceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "GrpcRetryPolicyEvents": {
+      "type": "list",
+      "member": {
+        "shape": "GrpcRetryPolicyEvent"
+      },
+      "min": 1,
+      "max": 5
+    },
+    "VirtualGatewayStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "ServiceUnavailableException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "ServiceUnavailableException",
+        "httpStatusCode": 503,
+        "fault": true
+      }
+    },
+    "DescribeMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData"
+        }
+      },
+      "payload": "mesh"
+    },
+    "DeleteVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "UpdateGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "DescribeRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "routeName"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "DeleteRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData"
+        }
+      },
+      "payload": "route"
+    },
+    "Listeners": {
+      "type": "list",
+      "member": {
+        "shape": "Listener"
+      },
+      "min": 0,
+      "max": 1
+    },
+    "Backends": {
+      "type": "list",
+      "member": {
+        "shape": "Backend"
+      }
+    },
+    "PortProtocol": {
+      "type": "string",
+      "enum": [
+        "grpc",
+        "http",
+        "http2",
+        "tcp"
+      ]
+    },
+    "DeleteGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "VirtualGatewayList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualGatewayRef"
+      }
+    },
+    "VirtualNodeStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "ServiceName": {
+      "type": "string"
+    },
+    "UpdateVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualServiceName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualServiceSpec"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "location": "uri",
+          "locationName": "virtualServiceName"
+        }
+      }
+    },
+    "HealthCheckThreshold": {
+      "type": "integer",
+      "min": 2,
+      "max": 10
+    },
+    "UpdateRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData"
+        }
+      },
+      "payload": "route"
+    },
+    "PercentInt": {
+      "type": "integer",
+      "min": 0,
+      "max": 100
+    },
+    "MethodName": {
+      "type": "string",
+      "min": 1,
+      "max": 50
+    },
+    "TagValue": {
+      "type": "string",
+      "min": 0,
+      "max": 256
+    },
+    "HttpRouteAction": {
+      "type": "structure",
+      "required": [
+        "weightedTargets"
+      ],
+      "members": {
+        "weightedTargets": {
+          "shape": "WeightedTargets"
+        }
+      }
+    },
+    "ListRoutesInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListRoutesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "VirtualServiceRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualServiceName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "GrpcTimeout": {
+      "type": "structure",
+      "members": {
+        "idle": {
+          "shape": "Duration"
+        },
+        "perRequest": {
+          "shape": "Duration"
+        }
+      }
+    },
+    "VirtualNodeStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualNodeStatusCode"
+        }
+      }
+    },
+    "VirtualRouterRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualRouterName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "VirtualServiceData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualServiceName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "VirtualServiceSpec"
+        },
+        "status": {
+          "shape": "VirtualServiceStatus"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "HttpRouteHeader": {
+      "type": "structure",
+      "required": [
+        "name"
+      ],
+      "members": {
+        "invert": {
+          "shape": "Boolean"
+        },
+        "match": {
+          "shape": "HeaderMatchMethod"
+        },
+        "name": {
+          "shape": "HeaderName"
+        }
+      }
+    },
+    "FilePath": {
+      "type": "string",
+      "min": 1,
+      "max": 255
+    },
+    "AwsCloudMapInstanceAttributes": {
+      "type": "list",
+      "member": {
+        "shape": "AwsCloudMapInstanceAttribute"
+      }
+    },
+    "VirtualNodeRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualNodeName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "CreateMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "spec": {
+          "shape": "MeshSpec"
+        }
+      }
+    },
+    "GrpcRouteAction": {
+      "type": "structure",
+      "required": [
+        "weightedTargets"
+      ],
+      "members": {
+        "weightedTargets": {
+          "shape": "WeightedTargets"
+        }
+      }
+    },
+    "VirtualGatewayTlsValidationContextFileTrust": {
+      "type": "structure",
+      "required": [
+        "certificateChain"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "LimitExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "LimitExceededException",
+        "httpStatusCode": 400,
+        "senderFault": true
+      }
+    },
+    "UpdateMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData"
+        }
+      },
+      "payload": "mesh"
+    },
+    "GrpcRouteMetadataMatchMethod": {
+      "type": "structure",
+      "members": {
+        "exact": {
+          "shape": "HeaderMatch"
+        },
+        "prefix": {
+          "shape": "HeaderMatch"
+        },
+        "range": {
+          "shape": "MatchRange"
+        },
+        "regex": {
+          "shape": "HeaderMatch"
+        },
+        "suffix": {
+          "shape": "HeaderMatch"
+        }
+      }
+    },
+    "DescribeVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualServiceName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "location": "uri",
+          "locationName": "virtualServiceName"
+        }
+      }
+    },
+    "ListVirtualServicesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "AwsCloudMapInstanceAttribute": {
+      "type": "structure",
+      "required": [
+        "key",
+        "value"
+      ],
+      "members": {
+        "key": {
+          "shape": "AwsCloudMapInstanceAttributeKey"
+        },
+        "value": {
+          "shape": "AwsCloudMapInstanceAttributeValue"
+        }
+      }
+    },
+    "VirtualGatewayListenerTlsMode": {
+      "type": "string",
+      "enum": [
+        "DISABLED",
+        "PERMISSIVE",
+        "STRICT"
+      ]
+    },
+    "VirtualServiceSpec": {
+      "type": "structure",
+      "members": {
+        "provider": {
+          "shape": "VirtualServiceProvider"
+        }
+      }
+    },
+    "VirtualGatewayTlsValidationContextAcmTrust": {
+      "type": "structure",
+      "required": [
+        "certificateAuthorityArns"
+      ],
+      "members": {
+        "certificateAuthorityArns": {
+          "shape": "VirtualGatewayCertificateAuthorityArns"
+        }
+      }
+    },
+    "VirtualGatewayAccessLog": {
+      "type": "structure",
+      "members": {
+        "file": {
+          "shape": "VirtualGatewayFileAccessLog"
+        }
+      }
+    },
+    "MatchRange": {
+      "type": "structure",
+      "required": [
+        "end",
+        "start"
+      ],
+      "members": {
+        "end": {
+          "shape": "Long"
+        },
+        "start": {
+          "shape": "Long"
+        }
+      }
+    },
+    "ListVirtualRoutersLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "HealthCheckIntervalMillis": {
+      "type": "long",
+      "box": true,
+      "min": 5000,
+      "max": 300000
+    },
+    "VirtualRouterList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualRouterRef"
+      }
+    },
+    "Arn": {
+      "type": "string"
+    },
+    "TcpRoute": {
+      "type": "structure",
+      "required": [
+        "action"
+      ],
+      "members": {
+        "action": {
+          "shape": "TcpRouteAction"
+        },
+        "timeout": {
+          "shape": "TcpTimeout",
+          "tags": [
+            "preview"
+          ]
+        }
+      }
+    },
+    "VirtualNodeList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualNodeRef"
+      }
+    },
+    "UpdateVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "ListVirtualRoutersInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualRoutersLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "DurationUnit": {
+      "type": "string",
+      "enum": [
+        "ms",
+        "s"
+      ]
+    },
+    "RoutePriority": {
+      "type": "integer",
+      "box": true,
+      "min": 0,
+      "max": 1000
+    },
+    "ListVirtualServicesInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualServicesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "AccessLog": {
+      "type": "structure",
+      "members": {
+        "file": {
+          "shape": "FileAccessLog"
+        }
+      }
+    },
+    "ListVirtualNodesInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualNodesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "VirtualGatewayClientPolicy": {
+      "type": "structure",
+      "members": {
+        "tls": {
+          "shape": "VirtualGatewayClientPolicyTls"
+        }
+      }
+    },
+    "ListVirtualNodesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "HealthCheckTimeoutMillis": {
+      "type": "long",
+      "box": true,
+      "min": 2000,
+      "max": 60000
+    },
+    "ResourceName": {
+      "type": "string",
+      "min": 1,
+      "max": 255
+    },
+    "TooManyRequestsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "exception": true,
+      "error": {
+        "code": "TooManyRequestsException",
+        "httpStatusCode": 429,
+        "senderFault": true
+      }
+    },
+    "Timestamp": {
+      "type": "timestamp"
+    },
+    "VirtualGatewayLogging": {
+      "type": "structure",
+      "members": {
+        "accessLog": {
+          "shape": "VirtualGatewayAccessLog"
+        }
+      }
+    },
+    "HeaderMatch": {
+      "type": "string",
+      "min": 1,
+      "max": 255
+    },
+    "AccountId": {
+      "type": "string",
+      "min": 12,
+      "max": 12
+    },
+    "GatewayRouteTarget": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "GatewayRouteVirtualService"
+        }
+      }
+    },
+    "Duration": {
+      "type": "structure",
+      "members": {
+        "unit": {
+          "shape": "DurationUnit"
+        },
+        "value": {
+          "shape": "DurationValue"
+        }
+      }
+    },
+    "DescribeRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData"
+        }
+      },
+      "payload": "route"
+    },
+    "HttpRouteMatch": {
+      "type": "structure",
+      "required": [
+        "prefix"
+      ],
+      "members": {
+        "headers": {
+          "shape": "HttpRouteHeaders"
+        },
+        "method": {
+          "shape": "HttpMethod"
+        },
+        "prefix": {
+          "shape": "String"
+        },
+        "scheme": {
+          "shape": "HttpScheme"
+        }
+      }
+    },
+    "TagRef": {
+      "type": "structure",
+      "required": [
+        "key"
+      ],
+      "members": {
+        "key": {
+          "shape": "TagKey"
+        },
+        "value": {
+          "shape": "TagValue"
+        }
+      }
+    },
+    "MeshRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long"
+        }
+      }
+    },
+    "ListVirtualGatewaysLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "MeshStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "MeshData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "MeshSpec"
+        },
+        "status": {
+          "shape": "MeshStatus"
+        }
+      }
+    },
+    "CreateGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "GatewayRouteList": {
+      "type": "list",
+      "member": {
+        "shape": "GatewayRouteRef"
+      }
+    },
+    "VirtualRouterStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualRouterStatusCode"
+        }
+      }
+    },
+    "TcpRouteAction": {
+      "type": "structure",
+      "required": [
+        "weightedTargets"
+      ],
+      "members": {
+        "weightedTargets": {
+          "shape": "WeightedTargets"
+        }
+      }
+    },
+    "DeleteVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "DescribeVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualNodeName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualNodeName"
+        }
+      }
+    },
+    "RouteStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "RouteStatusCode"
+        }
+      }
+    },
+    "Listener": {
+      "type": "structure",
+      "required": [
+        "portMapping"
+      ],
+      "members": {
+        "healthCheck": {
+          "shape": "HealthCheckPolicy"
+        },
+        "portMapping": {
+          "shape": "PortMapping"
+        },
+        "timeout": {
+          "shape": "ListenerTimeout",
+          "tags": [
+            "preview"
+          ]
+        },
+        "tls": {
+          "shape": "ListenerTls"
+        }
+      }
+    },
+    "GrpcRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "GrpcRouteAction"
+        },
+        "match": {
+          "shape": "GrpcRouteMatch"
+        },
+        "retryPolicy": {
+          "shape": "GrpcRetryPolicy"
+        },
+        "timeout": {
+          "shape": "GrpcTimeout",
+          "tags": [
+            "preview"
+          ]
+        }
+      }
+    },
+    "ListRoutesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "ClientPolicyTls": {
+      "type": "structure",
+      "required": [
+        "validation"
+      ],
+      "members": {
+        "enforce": {
+          "shape": "Boolean",
+          "box": true
+        },
+        "ports": {
+          "shape": "PortSet"
+        },
+        "validation": {
+          "shape": "TlsValidationContext"
+        }
+      }
+    },
+    "VirtualGatewayTlsValidationContextTrust": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "VirtualGatewayTlsValidationContextAcmTrust"
+        },
+        "file": {
+          "shape": "VirtualGatewayTlsValidationContextFileTrust"
+        }
+      }
+    },
+    "DeleteVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData"
+        }
+      },
+      "payload": "virtualService"
+    },
+    "VirtualGatewayPortProtocol": {
+      "type": "string",
+      "enum": [
+        "grpc",
+        "http",
+        "http2"
+      ]
+    },
+    "VirtualNodeServiceProvider": {
+      "type": "structure",
+      "required": [
+        "virtualNodeName"
+      ],
+      "members": {
+        "virtualNodeName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "HttpGatewayRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "HttpGatewayRouteAction"
+        },
+        "match": {
+          "shape": "HttpGatewayRouteMatch"
+        }
+      }
+    },
+    "BackendDefaults": {
+      "type": "structure",
+      "members": {
+        "clientPolicy": {
+          "shape": "ClientPolicy"
+        }
+      }
+    },
+    "ListenerTlsFileCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateChain",
+        "privateKey"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath"
+        },
+        "privateKey": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "HttpRetryPolicy": {
+      "type": "structure",
+      "required": [
+        "maxRetries",
+        "perRetryTimeout"
+      ],
+      "members": {
+        "httpRetryEvents": {
+          "shape": "HttpRetryPolicyEvents"
+        },
+        "maxRetries": {
+          "shape": "MaxRetries"
+        },
+        "perRetryTimeout": {
+          "shape": "Duration"
+        },
+        "tcpRetryEvents": {
+          "shape": "TcpRetryPolicyEvents"
+        }
+      }
+    },
+    "DescribeVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "RouteList": {
+      "type": "list",
+      "member": {
+        "shape": "RouteRef"
+      }
+    },
+    "UpdateGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "gatewayRouteName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "gatewayRouteName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "GatewayRouteSpec"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "ListVirtualGatewaysInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualGatewaysLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "PortNumber": {
+      "type": "integer",
+      "min": 1,
+      "max": 65535
+    },
+    "TlsValidationContextFileTrust": {
+      "type": "structure",
+      "required": [
+        "certificateChain"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "GrpcRouteMetadata": {
+      "type": "structure",
+      "required": [
+        "name"
+      ],
+      "members": {
+        "invert": {
+          "shape": "Boolean"
+        },
+        "match": {
+          "shape": "GrpcRouteMetadataMatchMethod"
+        },
+        "name": {
+          "shape": "HeaderName"
+        }
+      }
+    },
+    "CreateRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName"
+        },
+        "spec": {
+          "shape": "RouteSpec"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "VirtualGatewayCertificateAuthorityArns": {
+      "type": "list",
+      "member": {
+        "shape": "Arn"
+      },
+      "min": 1,
+      "max": 3
+    },
+    "WeightedTargets": {
+      "type": "list",
+      "member": {
+        "shape": "WeightedTarget"
+      },
+      "min": 1,
+      "max": 10
+    },
+    "HttpRouteHeaders": {
+      "type": "list",
+      "member": {
+        "shape": "HttpRouteHeader"
+      },
+      "min": 1,
+      "max": 10
+    },
+    "String": {
+      "type": "string"
+    },
+    "TcpTimeout": {
+      "type": "structure",
+      "members": {
+        "idle": {
+          "shape": "Duration"
+        }
+      }
+    },
+    "HttpScheme": {
+      "type": "string",
+      "enum": [
+        "http",
+        "https"
+      ]
+    },
+    "DeleteGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "gatewayRouteName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "gatewayRouteName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "UpdateRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "routeName"
+        },
+        "spec": {
+          "shape": "RouteSpec"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      }
+    },
+    "HttpRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "HttpRouteAction"
+        },
+        "match": {
+          "shape": "HttpRouteMatch"
+        },
+        "retryPolicy": {
+          "shape": "HttpRetryPolicy"
+        },
+        "timeout": {
+          "shape": "HttpTimeout",
+          "tags": [
+            "preview"
+          ]
+        }
+      }
+    },
+    "DescribeMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        }
+      }
+    },
+    "VirtualGatewayRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "MeshSpec": {
+      "type": "structure",
+      "members": {
+        "egressFilter": {
+          "shape": "EgressFilter"
+        }
+      }
+    },
+    "DescribeVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "DescribeGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "ServiceDiscovery": {
+      "type": "structure",
+      "members": {
+        "awsCloudMap": {
+          "shape": "AwsCloudMapServiceDiscovery"
+        },
+        "dns": {
+          "shape": "DnsServiceDiscovery"
+        }
+      }
+    },
+    "ListVirtualNodesOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNodes"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "virtualNodes": {
+          "shape": "VirtualNodeList"
+        }
+      }
+    },
+    "ListenerTlsAcmCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateArn"
+      ],
+      "members": {
+        "certificateArn": {
+          "shape": "Arn"
+        }
+      }
+    },
+    "TagKey": {
+      "type": "string",
+      "min": 1,
+      "max": 128
+    },
+    "VirtualServiceStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    }
+  }
+}

--- a/appmesh-preview/sdk/api.normal.json
+++ b/appmesh-preview/sdk/api.normal.json
@@ -1,0 +1,5519 @@
+{
+  "version": "2.0",
+  "metadata": {
+    "apiVersion": "2019-01-25",
+    "endpointPrefix": "appmesh-preview",
+    "jsonVersion": "1.1",
+    "protocol": "rest-json",
+    "serviceFullName": "AWS App Mesh Preview",
+    "serviceId": "App Mesh Preview",
+    "signatureVersion": "v4",
+    "signingName": "appmesh-preview",
+    "uid": "appmesh-preview-2019-01-25"
+  },
+  "documentation": "<p>AWS App Mesh is a service mesh based on the Envoy proxy that makes it easy to monitor and\n         control microservices. App Mesh standardizes how your microservices communicate, giving you\n         end-to-end visibility and helping to ensure high availability for your applications.</p>\n         <p>App Mesh gives you consistent visibility and network traffic controls for every\n         microservice in an application. You can use App Mesh with AWS Fargate, Amazon ECS, Amazon EKS,\n         Kubernetes on AWS, and Amazon EC2.</p>\n         <note>\n            <p>App Mesh supports microservice applications that use service discovery naming for their\n            components. For more information about service discovery on Amazon ECS, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html\">Service Discovery</a> in the <i>Amazon Elastic Container Service Developer Guide</i>. Kubernetes\n               <code>kube-dns</code> and <code>coredns</code> are supported. For more information,\n            see <a href=\"https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/\">DNS\n               for Services and Pods</a> in the Kubernetes documentation.</p>\n         </note>",
+  "operations": {
+    "CreateGatewayRoute": {
+      "name": "CreateGatewayRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateGatewayRouteInput"
+      },
+      "output": {
+        "shape": "CreateGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateMesh": {
+      "name": "CreateMesh",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateMeshInput"
+      },
+      "output": {
+        "shape": "CreateMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Creates a service mesh.</p>\n         <p> A service mesh is a logical boundary for network traffic between services that are\n         represented by resources within the mesh. After you create your service mesh, you can\n         create virtual services, virtual nodes, virtual routers, and routes to distribute traffic\n         between the applications in your mesh.</p>\n         <p>For more information about service meshes, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/meshes.html\">Service meshes</a>.</p>",
+      "idempotent": true
+    },
+    "CreateRoute": {
+      "name": "CreateRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateRouteInput"
+      },
+      "output": {
+        "shape": "CreateRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Creates a route that is associated with a virtual router.</p>\n         <p> You can route several different protocols and define a retry policy for a route.\n         Traffic can be routed to one or more virtual nodes.</p>\n         <p>For more information about routes, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/routes.html\">Routes</a>.</p>",
+      "idempotent": true
+    },
+    "CreateVirtualGateway": {
+      "name": "CreateVirtualGateway",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "CreateVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "CreateVirtualNode": {
+      "name": "CreateVirtualNode",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualNodeInput"
+      },
+      "output": {
+        "shape": "CreateVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Creates a virtual node within a service mesh.</p>\n         <p> A virtual node acts as a logical pointer to a particular task group, such as an Amazon ECS\n         service or a Kubernetes deployment. When you create a virtual node, you can specify the\n         service discovery information for your task group, and whether the proxy running in a task\n         group will communicate with other proxies using Transport Layer Security (TLS).</p>\n         <p>You define a <code>listener</code> for any inbound traffic that your virtual node\n         expects. Any virtual service that your virtual node expects to communicate to is specified\n         as a <code>backend</code>.</p>\n         <p>The response metadata for your new virtual node contains the <code>arn</code> that is\n         associated with the virtual node. Set this value (either the full ARN or the truncated\n         resource name: for example, <code>mesh/default/virtualNode/simpleapp</code>) as the\n            <code>APPMESH_VIRTUAL_NODE_NAME</code> environment variable for your task group's Envoy\n         proxy container in your task definition or pod spec. This is then mapped to the\n            <code>node.id</code> and <code>node.cluster</code> Envoy parameters.</p>\n         <note>\n            <p>If you require your Envoy stats or tracing to use a different name, you can override\n            the <code>node.cluster</code> value that is set by\n               <code>APPMESH_VIRTUAL_NODE_NAME</code> with the\n               <code>APPMESH_VIRTUAL_NODE_CLUSTER</code> environment variable.</p>\n         </note>\n         <p>For more information about virtual nodes, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_nodes.html\">Virtual nodes</a>.</p>",
+      "idempotent": true
+    },
+    "CreateVirtualRouter": {
+      "name": "CreateVirtualRouter",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualRouterInput"
+      },
+      "output": {
+        "shape": "CreateVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Creates a virtual router within a service mesh.</p>\n         <p>Specify a <code>listener</code> for any inbound traffic that your virtual router\n         receives. Create a virtual router for each protocol and port that you need to route.\n         Virtual routers handle traffic for one or more virtual services within your mesh. After you\n         create your virtual router, create and associate routes for your virtual router that direct\n         incoming requests to different virtual nodes.</p>\n         <p>For more information about virtual routers, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_routers.html\">Virtual routers</a>.</p>",
+      "idempotent": true
+    },
+    "CreateVirtualService": {
+      "name": "CreateVirtualService",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "CreateVirtualServiceInput"
+      },
+      "output": {
+        "shape": "CreateVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Creates a virtual service within a service mesh.</p>\n         <p>A virtual service is an abstraction of a real service that is provided by a virtual node\n         directly or indirectly by means of a virtual router. Dependent services call your virtual\n         service by its <code>virtualServiceName</code>, and those requests are routed to the\n         virtual node or virtual router that is specified as the provider for the virtual\n         service.</p>\n         <p>For more information about virtual services, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_services.html\">Virtual services</a>.</p>",
+      "idempotent": true
+    },
+    "DeleteGatewayRoute": {
+      "name": "DeleteGatewayRoute",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes/{gatewayRouteName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteGatewayRouteInput"
+      },
+      "output": {
+        "shape": "DeleteGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteMesh": {
+      "name": "DeleteMesh",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteMeshInput"
+      },
+      "output": {
+        "shape": "DeleteMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Deletes an existing service mesh.</p>\n         <p>You must delete all resources (virtual services, routes, virtual routers, and virtual\n         nodes) in the service mesh before you can delete the mesh itself.</p>",
+      "idempotent": true
+    },
+    "DeleteRoute": {
+      "name": "DeleteRoute",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteRouteInput"
+      },
+      "output": {
+        "shape": "DeleteRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Deletes an existing route.</p>",
+      "idempotent": true
+    },
+    "DeleteVirtualGateway": {
+      "name": "DeleteVirtualGateway",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways/{virtualGatewayName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "DeleteVirtualNode": {
+      "name": "DeleteVirtualNode",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualNodeInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Deletes an existing virtual node.</p>\n         <p>You must delete any virtual services that list a virtual node as a service provider\n         before you can delete the virtual node itself.</p>",
+      "idempotent": true
+    },
+    "DeleteVirtualRouter": {
+      "name": "DeleteVirtualRouter",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualRouterInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Deletes an existing virtual router.</p>\n         <p>You must delete any routes associated with the virtual router before you can delete the\n         router itself.</p>",
+      "idempotent": true
+    },
+    "DeleteVirtualService": {
+      "name": "DeleteVirtualService",
+      "http": {
+        "method": "DELETE",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DeleteVirtualServiceInput"
+      },
+      "output": {
+        "shape": "DeleteVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ResourceInUseException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Deletes an existing virtual service.</p>",
+      "idempotent": true
+    },
+    "DescribeGatewayRoute": {
+      "name": "DescribeGatewayRoute",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes/{gatewayRouteName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeGatewayRouteInput"
+      },
+      "output": {
+        "shape": "DescribeGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeMesh": {
+      "name": "DescribeMesh",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeMeshInput"
+      },
+      "output": {
+        "shape": "DescribeMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Describes an existing service mesh.</p>"
+    },
+    "DescribeRoute": {
+      "name": "DescribeRoute",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeRouteInput"
+      },
+      "output": {
+        "shape": "DescribeRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Describes an existing route.</p>"
+    },
+    "DescribeVirtualGateway": {
+      "name": "DescribeVirtualGateway",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways/{virtualGatewayName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "DescribeVirtualNode": {
+      "name": "DescribeVirtualNode",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualNodeInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Describes an existing virtual node.</p>"
+    },
+    "DescribeVirtualRouter": {
+      "name": "DescribeVirtualRouter",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualRouterInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Describes an existing virtual router.</p>"
+    },
+    "DescribeVirtualService": {
+      "name": "DescribeVirtualService",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "DescribeVirtualServiceInput"
+      },
+      "output": {
+        "shape": "DescribeVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Describes an existing virtual service.</p>"
+    },
+    "ListGatewayRoutes": {
+      "name": "ListGatewayRoutes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListGatewayRoutesInput"
+      },
+      "output": {
+        "shape": "ListGatewayRoutesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListMeshes": {
+      "name": "ListMeshes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListMeshesInput"
+      },
+      "output": {
+        "shape": "ListMeshesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Returns a list of existing service meshes.</p>"
+    },
+    "ListRoutes": {
+      "name": "ListRoutes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListRoutesInput"
+      },
+      "output": {
+        "shape": "ListRoutesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Returns a list of existing routes in a service mesh.</p>"
+    },
+    "ListVirtualGateways": {
+      "name": "ListVirtualGateways",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualGatewaysInput"
+      },
+      "output": {
+        "shape": "ListVirtualGatewaysOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ]
+    },
+    "ListVirtualNodes": {
+      "name": "ListVirtualNodes",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualNodesInput"
+      },
+      "output": {
+        "shape": "ListVirtualNodesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Returns a list of existing virtual nodes.</p>"
+    },
+    "ListVirtualRouters": {
+      "name": "ListVirtualRouters",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualRoutersInput"
+      },
+      "output": {
+        "shape": "ListVirtualRoutersOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Returns a list of existing virtual routers in a service mesh.</p>"
+    },
+    "ListVirtualServices": {
+      "name": "ListVirtualServices",
+      "http": {
+        "method": "GET",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "ListVirtualServicesInput"
+      },
+      "output": {
+        "shape": "ListVirtualServicesOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Returns a list of existing virtual services in a service mesh.</p>"
+    },
+    "UpdateGatewayRoute": {
+      "name": "UpdateGatewayRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateway/{virtualGatewayName}/gatewayRoutes/{gatewayRouteName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateGatewayRouteInput"
+      },
+      "output": {
+        "shape": "UpdateGatewayRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateMesh": {
+      "name": "UpdateMesh",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateMeshInput"
+      },
+      "output": {
+        "shape": "UpdateMeshOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Updates an existing service mesh.</p>",
+      "idempotent": true
+    },
+    "UpdateRoute": {
+      "name": "UpdateRoute",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouter/{virtualRouterName}/routes/{routeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateRouteInput"
+      },
+      "output": {
+        "shape": "UpdateRouteOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Updates an existing route for a specified service mesh and virtual router.</p>",
+      "idempotent": true
+    },
+    "UpdateVirtualGateway": {
+      "name": "UpdateVirtualGateway",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualGateways/{virtualGatewayName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualGatewayInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualGatewayOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "idempotent": true
+    },
+    "UpdateVirtualNode": {
+      "name": "UpdateVirtualNode",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualNodes/{virtualNodeName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualNodeInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualNodeOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Updates an existing virtual node in a specified service mesh.</p>",
+      "idempotent": true
+    },
+    "UpdateVirtualRouter": {
+      "name": "UpdateVirtualRouter",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualRouters/{virtualRouterName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualRouterInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualRouterOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Updates an existing virtual router in a specified service mesh.</p>",
+      "idempotent": true
+    },
+    "UpdateVirtualService": {
+      "name": "UpdateVirtualService",
+      "http": {
+        "method": "PUT",
+        "requestUri": "/v20190125/meshes/{meshName}/virtualServices/{virtualServiceName}",
+        "responseCode": 200
+      },
+      "input": {
+        "shape": "UpdateVirtualServiceInput"
+      },
+      "output": {
+        "shape": "UpdateVirtualServiceOutput"
+      },
+      "errors": [
+        {
+          "shape": "BadRequestException"
+        },
+        {
+          "shape": "ConflictException"
+        },
+        {
+          "shape": "ForbiddenException"
+        },
+        {
+          "shape": "InternalServerErrorException"
+        },
+        {
+          "shape": "LimitExceededException"
+        },
+        {
+          "shape": "NotFoundException"
+        },
+        {
+          "shape": "ServiceUnavailableException"
+        },
+        {
+          "shape": "TooManyRequestsException"
+        }
+      ],
+      "documentation": "<p>Updates an existing virtual service in a specified service mesh.</p>",
+      "idempotent": true
+    }
+  },
+  "shapes": {
+    "VirtualRouterListener": {
+      "type": "structure",
+      "required": [
+        "portMapping"
+      ],
+      "members": {
+        "portMapping": {
+          "shape": "PortMapping"
+        }
+      },
+      "documentation": "<p>An object that represents a virtual router listener.</p>"
+    },
+    "VirtualRouterStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "GrpcRetryPolicy": {
+      "type": "structure",
+      "required": [
+        "maxRetries",
+        "perRetryTimeout"
+      ],
+      "members": {
+        "grpcRetryEvents": {
+          "shape": "GrpcRetryPolicyEvents",
+          "documentation": "<p>Specify at least one of the valid values.</p>"
+        },
+        "httpRetryEvents": {
+          "shape": "HttpRetryPolicyEvents",
+          "documentation": "<p>Specify at least one of the following values.</p> \n         <ul>\n            <li>\n               <p>\n                  <b>server-error</b> – HTTP status codes 500, 501,\n                  502, 503, 504, 505, 506, 507, 508, 510, and 511</p>\n            </li>\n            <li>\n               <p>\n                  <b>gateway-error</b> – HTTP status codes 502,\n                  503, and 504</p>\n            </li>\n            <li>\n               <p>\n                  <b>client-error</b> – HTTP status code 409</p>\n            </li>\n            <li>\n               <p>\n                  <b>stream-error</b> – Retry on refused\n                  stream</p>\n            </li>\n         </ul>"
+        },
+        "maxRetries": {
+          "shape": "MaxRetries",
+          "documentation": "<p>The maximum number of retry attempts.</p>"
+        },
+        "perRetryTimeout": {
+          "shape": "Duration",
+          "documentation": "<p>An object that represents a duration of time.</p>"
+        },
+        "tcpRetryEvents": {
+          "shape": "TcpRetryPolicyEvents",
+          "documentation": "<p>Specify a valid value.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a retry policy. Specify at least one value for at least one of the types of <code>RetryEvents</code>, a value for <code>maxRetries</code>, and a value for <code>perRetryTimeout</code>.</p>"
+    },
+    "CreateVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData",
+          "documentation": "<p>The full description of your virtual node following the create call.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualNode"
+    },
+    "Logging": {
+      "type": "structure",
+      "members": {
+        "accessLog": {
+          "shape": "AccessLog",
+          "documentation": "<p>The access log configuration for a virtual node.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the logging information for a virtual node.</p>"
+    },
+    "Long": {
+      "type": "long",
+      "box": true
+    },
+    "UpdateVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData",
+          "documentation": "<p>A full description of the virtual router that was updated.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualRouter"
+    },
+    "ListVirtualRoutersOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouters"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String",
+          "documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListVirtualRouters</code>\n         request. When the results of a <code>ListVirtualRouters</code> request exceed\n            <code>limit</code>, you can use this value to retrieve the next page of results. This\n         value is <code>null</code> when there are no more results to return.</p>"
+        },
+        "virtualRouters": {
+          "shape": "VirtualRouterList",
+          "documentation": "<p>The list of existing virtual routers for the specified service mesh.</p>"
+        }
+      },
+      "documentation": ""
+    },
+    "CreateVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualGatewaySpec"
+        },
+        "tags": {
+          "shape": "TagList"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "UpdateVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualGatewaySpec"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "ResourceMetadata": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshOwner",
+        "resourceOwner",
+        "uid",
+        "version"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn",
+          "documentation": "<p>The full Amazon Resource Name (ARN) for the resource.</p>"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "resourceOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "uid": {
+          "shape": "String",
+          "documentation": "<p>The unique identifier for the resource.</p>"
+        },
+        "version": {
+          "shape": "Long",
+          "documentation": "<p>The version of the resource. Resources are created at version 1, and this version is\n         incremented each time that they're updated.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents metadata for a resource.</p>"
+    },
+    "ResourceInUseException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "documentation": "<p>You can't delete the specified resource because it's in use or required by another\n         resource.</p>",
+      "exception": true,
+      "error": {
+        "code": "ResourceInUseException",
+        "httpStatusCode": 409,
+        "senderFault": true
+      }
+    },
+    "UpdateVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData",
+          "documentation": "<p>A full description of the virtual node that was updated.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualNode"
+    },
+    "ListRoutesOutput": {
+      "type": "structure",
+      "required": [
+        "routes"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String",
+          "documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListRoutes</code> request.\n         When the results of a <code>ListRoutes</code> request exceed <code>limit</code>, you can\n         use this value to retrieve the next page of results. This value is <code>null</code> when\n         there are no more results to return.</p>"
+        },
+        "routes": {
+          "shape": "RouteList",
+          "documentation": "<p>The list of existing routes for the specified service mesh and virtual router.</p>"
+        }
+      },
+      "documentation": ""
+    },
+    "VirtualServiceBackend": {
+      "type": "structure",
+      "required": [
+        "virtualServiceName"
+      ],
+      "members": {
+        "clientPolicy": {
+          "shape": "ClientPolicy",
+          "documentation": "<p>A reference to an object that represents the client policy for a backend.</p>"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "documentation": "<p>The name of the virtual service that is acting as a virtual node backend.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a virtual service backend for a virtual node.</p>"
+    },
+    "BadRequestException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "documentation": "<p>The request syntax was malformed. Check your request syntax and try again.</p>",
+      "exception": true,
+      "error": {
+        "code": "BadRequestException",
+        "httpStatusCode": 400,
+        "senderFault": true
+      }
+    },
+    "HttpGatewayRouteMatch": {
+      "type": "structure",
+      "required": [
+        "prefix"
+      ],
+      "members": {
+        "prefix": {
+          "shape": "String"
+        }
+      }
+    },
+    "GrpcRouteMetadataList": {
+      "type": "list",
+      "member": {
+        "shape": "GrpcRouteMetadata"
+      },
+      "min": 1,
+      "max": 10
+    },
+    "ListenerTlsMode": {
+      "type": "string",
+      "enum": [
+        "DISABLED",
+        "PERMISSIVE",
+        "STRICT"
+      ]
+    },
+    "HealthCheckPolicy": {
+      "type": "structure",
+      "required": [
+        "healthyThreshold",
+        "intervalMillis",
+        "protocol",
+        "timeoutMillis",
+        "unhealthyThreshold"
+      ],
+      "members": {
+        "healthyThreshold": {
+          "shape": "HealthCheckThreshold",
+          "documentation": "<p>The number of consecutive successful health checks that must occur before declaring\n         listener healthy.</p>"
+        },
+        "intervalMillis": {
+          "shape": "HealthCheckIntervalMillis",
+          "documentation": "<p>The time period in milliseconds between each health check execution.</p>"
+        },
+        "path": {
+          "shape": "String",
+          "documentation": "<p>The destination path for the health check request. This value is only used if the\n         specified protocol is HTTP or HTTP/2. For any other protocol, this value is ignored.</p>"
+        },
+        "port": {
+          "shape": "PortNumber",
+          "documentation": "<p>The destination port for the health check request. This port must match the port defined\n         in the <a>PortMapping</a> for the listener.</p>"
+        },
+        "protocol": {
+          "shape": "PortProtocol",
+          "documentation": "<p>The protocol for the health check request. If you specify <code>grpc</code>, then your\n         service must conform to the <a href=\"https://github.com/grpc/grpc/blob/master/doc/health-checking.md\">GRPC Health\n            Checking Protocol</a>.</p>"
+        },
+        "timeoutMillis": {
+          "shape": "HealthCheckTimeoutMillis",
+          "documentation": "<p>The amount of time to wait when receiving a response from the health check, in\n         milliseconds.</p>"
+        },
+        "unhealthyThreshold": {
+          "shape": "HealthCheckThreshold",
+          "documentation": "<p>The number of consecutive failed health checks that must occur before declaring a\n         virtual node unhealthy. </p>"
+        }
+      },
+      "documentation": "<p>An object that represents the health check policy for a virtual node's listener.</p>"
+    },
+    "VirtualGatewayHealthCheckTimeoutMillis": {
+      "type": "long",
+      "box": true,
+      "min": 2000,
+      "max": 60000
+    },
+    "EgressFilter": {
+      "type": "structure",
+      "required": [
+        "type"
+      ],
+      "members": {
+        "type": {
+          "shape": "EgressFilterType",
+          "documentation": "<p>The egress filter type. By default, the type is <code>DROP_ALL</code>, which allows\n         egress only from virtual nodes to other defined resources in the service mesh (and any\n         traffic to <code>*.amazonaws.com</code> for AWS API calls). You can set the egress filter\n         type to <code>ALLOW_ALL</code> to allow egress to any endpoint inside or outside of the\n         service mesh.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the egress filter rules for a service mesh.</p>"
+    },
+    "VirtualServiceList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualServiceRef"
+      }
+    },
+    "ClientPolicy": {
+      "type": "structure",
+      "members": {
+        "tls": {
+          "shape": "ClientPolicyTls",
+          "documentation": "<p>A reference to an object that represents a Transport Layer Security (TLS) client policy.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a client policy.</p>"
+    },
+    "VirtualGatewayHealthCheckIntervalMillis": {
+      "type": "long",
+      "box": true,
+      "min": 5000,
+      "max": 300000
+    },
+    "Boolean": {
+      "type": "boolean",
+      "box": true
+    },
+    "VirtualGatewaySpec": {
+      "type": "structure",
+      "required": [
+        "listeners"
+      ],
+      "members": {
+        "backendDefaults": {
+          "shape": "VirtualGatewayBackendDefaults"
+        },
+        "listeners": {
+          "shape": "VirtualGatewayListeners"
+        }
+      }
+    },
+    "HttpRetryPolicyEvent": {
+      "type": "string",
+      "min": 1,
+      "max": 25
+    },
+    "VirtualGatewayFileAccessLog": {
+      "type": "structure",
+      "required": [
+        "path"
+      ],
+      "members": {
+        "path": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "DescribeVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData",
+          "documentation": "<p>The full description of your virtual service.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualService"
+    },
+    "CreateGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "gatewayRouteName": {
+          "shape": "ResourceName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "GatewayRouteSpec"
+        },
+        "tags": {
+          "shape": "TagList"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "CertificateAuthorityArns": {
+      "type": "list",
+      "member": {
+        "shape": "Arn"
+      },
+      "min": 1,
+      "max": 3
+    },
+    "DescribeVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData",
+          "documentation": "<p>The full description of your virtual node.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualNode"
+    },
+    "AwsCloudMapName": {
+      "type": "string",
+      "min": 1,
+      "max": 1024,
+      "pattern": "((?=^.{1,127}$)^([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9])(.([a-zA-Z0-9_][a-zA-Z0-9-_]{0,61}[a-zA-Z0-9_]|[a-zA-Z0-9]))*$)|(^.$)"
+    },
+    "VirtualGatewayData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "VirtualGatewaySpec"
+        },
+        "status": {
+          "shape": "VirtualGatewayStatus"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "CreateRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData",
+          "documentation": "<p>The full description of your mesh following the create call.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "route"
+    },
+    "VirtualGatewayListener": {
+      "type": "structure",
+      "required": [
+        "portMapping"
+      ],
+      "members": {
+        "healthCheck": {
+          "shape": "VirtualGatewayHealthCheckPolicy"
+        },
+        "logging": {
+          "shape": "VirtualGatewayLogging"
+        },
+        "portMapping": {
+          "shape": "VirtualGatewayPortMapping"
+        },
+        "tls": {
+          "shape": "VirtualGatewayListenerTls"
+        }
+      }
+    },
+    "DnsServiceDiscovery": {
+      "type": "structure",
+      "required": [
+        "hostname"
+      ],
+      "members": {
+        "hostname": {
+          "shape": "Hostname",
+          "documentation": "<p>Specifies the DNS service discovery hostname for the virtual node. </p>"
+        }
+      },
+      "documentation": "<p>An object that represents the DNS service discovery information for your virtual\n         node.</p>"
+    },
+    "VirtualGatewayPortMapping": {
+      "type": "structure",
+      "required": [
+        "port",
+        "protocol"
+      ],
+      "members": {
+        "port": {
+          "shape": "PortNumber"
+        },
+        "protocol": {
+          "shape": "VirtualGatewayPortProtocol"
+        }
+      }
+    },
+    "DeleteVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "DeleteRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to delete the route in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the route to delete.</p>",
+          "location": "uri",
+          "locationName": "routeName"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router to delete the route in.</p>",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      },
+      "documentation": ""
+    },
+    "VirtualNodeData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualNodeName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual node resides in.</p>"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata",
+          "documentation": "<p>The associated metadata for the virtual node.</p>"
+        },
+        "spec": {
+          "shape": "VirtualNodeSpec",
+          "documentation": "<p>The specifications of the virtual node.</p>"
+        },
+        "status": {
+          "shape": "VirtualNodeStatus",
+          "documentation": "<p>The current status for the virtual node.</p>"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual node.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a virtual node returned by a describe operation.</p>"
+    },
+    "ListGatewayRoutesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "TcpRetryPolicyEvent": {
+      "type": "string",
+      "enum": [
+        "connection-error"
+      ]
+    },
+    "VirtualGatewayListenerTls": {
+      "type": "structure",
+      "required": [
+        "certificate",
+        "mode"
+      ],
+      "members": {
+        "certificate": {
+          "shape": "VirtualGatewayListenerTlsCertificate"
+        },
+        "mode": {
+          "shape": "VirtualGatewayListenerTlsMode"
+        }
+      }
+    },
+    "Backend": {
+      "type": "structure",
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceBackend",
+          "documentation": "<p>Specifies a virtual service to use as a backend for a virtual node. </p>"
+        }
+      },
+      "documentation": "<p>An object that represents the backends that a virtual node is expected to send outbound\n         traffic to. </p>"
+    },
+    "ListMeshesInput": {
+      "type": "structure",
+      "members": {
+        "limit": {
+          "shape": "ListMeshesLimit",
+          "documentation": "<p>The maximum number of results returned by <code>ListMeshes</code> in paginated output.\n         When you use this parameter, <code>ListMeshes</code> returns only <code>limit</code>\n         results in a single page along with a <code>nextToken</code> response element. You can see\n         the remaining results of the initial request by sending another <code>ListMeshes</code>\n         request with the returned <code>nextToken</code> value. This value can be between\n         1 and 100. If you don't use this parameter,\n            <code>ListMeshes</code> returns up to 100 results and a\n            <code>nextToken</code> value if applicable.</p>",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "nextToken": {
+          "shape": "String",
+          "documentation": "<p>The <code>nextToken</code> value returned from a previous paginated\n            <code>ListMeshes</code> request where <code>limit</code> was used and the results\n         exceeded the value of that parameter. Pagination continues from the end of the previous\n         results that returned the <code>nextToken</code> value.</p> \n         <note>\n            <p>This token should be treated as an opaque identifier that is used only to\n                retrieve the next items in a list and not for other programmatic purposes.</p>\n        </note>",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      },
+      "documentation": ""
+    },
+    "VirtualGatewayListenerTlsFileCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateChain",
+        "privateKey"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath"
+        },
+        "privateKey": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "ListGatewayRoutesInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListGatewayRoutesLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "VirtualRouterData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual router resides in.</p>"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata",
+          "documentation": "<p>The associated metadata for the virtual router.</p>"
+        },
+        "spec": {
+          "shape": "VirtualRouterSpec",
+          "documentation": "<p>The specifications of the virtual router.</p>"
+        },
+        "status": {
+          "shape": "VirtualRouterStatus",
+          "documentation": "<p>The current status of the virtual router.</p>"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a virtual router returned by a describe operation.</p>"
+    },
+    "UpdateMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "documentation": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to update.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "spec": {
+          "shape": "MeshSpec",
+          "documentation": "<p>The service mesh specification to apply.</p>"
+        }
+      },
+      "documentation": ""
+    },
+    "VirtualGatewayHealthCheckPolicy": {
+      "type": "structure",
+      "required": [
+        "healthyThreshold",
+        "intervalMillis",
+        "protocol",
+        "timeoutMillis",
+        "unhealthyThreshold"
+      ],
+      "members": {
+        "healthyThreshold": {
+          "shape": "VirtualGatewayHealthCheckThreshold"
+        },
+        "intervalMillis": {
+          "shape": "VirtualGatewayHealthCheckIntervalMillis"
+        },
+        "path": {
+          "shape": "String"
+        },
+        "port": {
+          "shape": "PortNumber"
+        },
+        "protocol": {
+          "shape": "VirtualGatewayPortProtocol"
+        },
+        "timeoutMillis": {
+          "shape": "VirtualGatewayHealthCheckTimeoutMillis"
+        },
+        "unhealthyThreshold": {
+          "shape": "VirtualGatewayHealthCheckThreshold"
+        }
+      }
+    },
+    "CreateVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "documentation": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to create the virtual router in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then\n               the account that you specify must share the mesh with your account before you can create \n             the resource in the service mesh. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualRouterSpec",
+          "documentation": "<p>The virtual router specification to apply.</p>"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name to use for the virtual router.</p>"
+        }
+      },
+      "documentation": ""
+    },
+    "DescribeVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData",
+          "documentation": "<p>The full description of your virtual router.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualRouter"
+    },
+    "CreateMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData",
+          "documentation": "<p>The full description of your service mesh following the create call.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "mesh"
+    },
+    "CreateVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData",
+          "documentation": "<p>The full description of your virtual router following the create call.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualRouter"
+    },
+    "VirtualServiceStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualServiceStatusCode",
+          "documentation": "<p>The current status of the virtual service.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the status of a virtual service.</p>"
+    },
+    "HttpRetryPolicyEvents": {
+      "type": "list",
+      "member": {
+        "shape": "HttpRetryPolicyEvent"
+      },
+      "min": 1,
+      "max": 25
+    },
+    "VirtualGatewayListenerTlsCertificate": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "VirtualGatewayListenerTlsAcmCertificate"
+        },
+        "file": {
+          "shape": "VirtualGatewayListenerTlsFileCertificate"
+        }
+      }
+    },
+    "ListenerTlsCertificate": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "ListenerTlsAcmCertificate",
+          "documentation": "<p>A reference to an object that represents an AWS Certicate Manager (ACM) certificate.</p>"
+        },
+        "file": {
+          "shape": "ListenerTlsFileCertificate",
+          "documentation": "<p>A reference to an object that represents a local file certificate.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a listener's Transport Layer Security (TLS) certificate.</p>"
+    },
+    "ListMeshesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "AwsCloudMapInstanceAttributeKey": {
+      "type": "string",
+      "min": 1,
+      "max": 255,
+      "pattern": "^[a-zA-Z0-9!-~]+$"
+    },
+    "VirtualRouterSpec": {
+      "type": "structure",
+      "members": {
+        "listeners": {
+          "shape": "VirtualRouterListeners",
+          "documentation": "<p>The listeners that the virtual router is expected to receive inbound traffic from. You\n         can specify one listener.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the specification of a virtual router.</p>"
+    },
+    "GatewayRouteVirtualService": {
+      "type": "structure",
+      "required": [
+        "virtualServiceName"
+      ],
+      "members": {
+        "virtualServiceName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "VirtualNodeSpec": {
+      "type": "structure",
+      "members": {
+        "backendDefaults": {
+          "shape": "BackendDefaults",
+          "documentation": "<p>A reference to an object that represents the defaults for backends.</p>"
+        },
+        "backends": {
+          "shape": "Backends",
+          "documentation": "<p>The backends that the virtual node is expected to send outbound traffic to.</p>"
+        },
+        "listeners": {
+          "shape": "Listeners",
+          "documentation": "<p>The listener that the virtual node is expected to receive inbound traffic from. You can\n         specify one listener.</p>"
+        },
+        "logging": {
+          "shape": "Logging",
+          "documentation": "<p>The inbound and outbound access logging information for the virtual node.</p>"
+        },
+        "serviceDiscovery": {
+          "shape": "ServiceDiscovery",
+          "documentation": "<p>The service discovery information for the virtual node. If your virtual node does not\n         expect ingress traffic, you can omit this parameter. If you specify a\n         <code>listener</code>, then you must specify service discovery information.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the specification of a virtual node.</p>"
+    },
+    "ListMeshesOutput": {
+      "type": "structure",
+      "required": [
+        "meshes"
+      ],
+      "members": {
+        "meshes": {
+          "shape": "MeshList",
+          "documentation": "<p>The list of existing service meshes.</p>"
+        },
+        "nextToken": {
+          "shape": "String",
+          "documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListMeshes</code> request.\n         When the results of a <code>ListMeshes</code> request exceed <code>limit</code>, you can\n         use this value to retrieve the next page of results. This value is <code>null</code> when\n         there are no more results to return.</p>"
+        }
+      },
+      "documentation": ""
+    },
+    "VirtualRouterListeners": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualRouterListener"
+      },
+      "min": 1,
+      "max": 1
+    },
+    "GatewayRouteSpec": {
+      "type": "structure",
+      "members": {
+        "grpcRoute": {
+          "shape": "GrpcGatewayRoute"
+        },
+        "http2Route": {
+          "shape": "HttpGatewayRoute"
+        },
+        "httpRoute": {
+          "shape": "HttpGatewayRoute"
+        }
+      }
+    },
+    "PortSet": {
+      "type": "list",
+      "member": {
+        "shape": "PortNumber"
+      }
+    },
+    "HttpMethod": {
+      "type": "string",
+      "enum": [
+        "CONNECT",
+        "DELETE",
+        "GET",
+        "HEAD",
+        "OPTIONS",
+        "PATCH",
+        "POST",
+        "PUT",
+        "TRACE"
+      ]
+    },
+    "ConflictException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "documentation": "<p>The request contains a client token that was used for a previous update resource call\n         with different specifications. Try the request again with a new client token.</p>",
+      "exception": true,
+      "error": {
+        "code": "ConflictException",
+        "httpStatusCode": 409,
+        "senderFault": true
+      }
+    },
+    "VirtualGatewayBackendDefaults": {
+      "type": "structure",
+      "members": {
+        "clientPolicy": {
+          "shape": "VirtualGatewayClientPolicy"
+        }
+      }
+    },
+    "ListenerTimeout": {
+      "type": "structure",
+      "members": {
+        "grpc": {
+          "shape": "GrpcTimeout"
+        },
+        "http": {
+          "shape": "HttpTimeout"
+        },
+        "http2": {
+          "shape": "HttpTimeout"
+        },
+        "tcp": {
+          "shape": "TcpTimeout"
+        }
+      }
+    },
+    "MeshList": {
+      "type": "list",
+      "member": {
+        "shape": "MeshRef"
+      }
+    },
+    "MaxRetries": {
+      "type": "long",
+      "box": true,
+      "min": 0
+    },
+    "DescribeGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "gatewayRouteName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "gatewayRouteName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "TlsValidationContextTrust": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "TlsValidationContextAcmTrust",
+          "documentation": "<p>A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM)\n         certificate.</p>"
+        },
+        "file": {
+          "shape": "TlsValidationContextFileTrust",
+          "documentation": "<p>An object that represents a TLS validation context trust for a local file.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a Transport Layer Security (TLS) validation context trust.</p>"
+    },
+    "PortMapping": {
+      "type": "structure",
+      "required": [
+        "port",
+        "protocol"
+      ],
+      "members": {
+        "port": {
+          "shape": "PortNumber",
+          "documentation": "<p>The port used for the port mapping.</p>"
+        },
+        "protocol": {
+          "shape": "PortProtocol",
+          "documentation": "<p>The protocol used for the port mapping. Specify one protocol.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a port mapping.</p>"
+    },
+    "VirtualGatewayHealthCheckThreshold": {
+      "type": "integer",
+      "min": 2,
+      "max": 10
+    },
+    "ListVirtualServicesOutput": {
+      "type": "structure",
+      "required": [
+        "virtualServices"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String",
+          "documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListVirtualServices</code>\n         request. When the results of a <code>ListVirtualServices</code> request exceed\n            <code>limit</code>, you can use this value to retrieve the next page of results. This\n         value is <code>null</code> when there are no more results to return.</p>"
+        },
+        "virtualServices": {
+          "shape": "VirtualServiceList",
+          "documentation": "<p>The list of existing virtual services for the specified service mesh.</p>"
+        }
+      },
+      "documentation": ""
+    },
+    "AwsCloudMapInstanceAttributeValue": {
+      "type": "string",
+      "min": 1,
+      "max": 1024,
+      "pattern": "^([a-zA-Z0-9!-~][ ta-zA-Z0-9!-~]*){0,1}[a-zA-Z0-9!-~]{0,1}$"
+    },
+    "WeightedTarget": {
+      "type": "structure",
+      "required": [
+        "virtualNode",
+        "weight"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "ResourceName",
+          "documentation": "<p>The virtual node to associate with the weighted target.</p>"
+        },
+        "weight": {
+          "shape": "PercentInt",
+          "documentation": "<p>The relative weight of the weighted target.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a target and its relative weight. Traffic is distributed\n         across targets according to their relative weight. For example, a weighted target with a\n         relative weight of 50 receives five times as much traffic as one with a relative weight of\n         10. The total weight for all targets combined must be less than or equal to 100.</p>"
+    },
+    "GrpcGatewayRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "GrpcGatewayRouteAction"
+        },
+        "match": {
+          "shape": "GrpcGatewayRouteMatch"
+        }
+      }
+    },
+    "GatewayRouteData": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "gatewayRouteName": {
+          "shape": "ResourceName"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "GatewayRouteSpec"
+        },
+        "status": {
+          "shape": "GatewayRouteStatus"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "RouteRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "routeName",
+        "version",
+        "virtualRouterName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn",
+          "documentation": "<p>The full Amazon Resource Name (ARN) for the route.</p>"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the route resides in.</p>"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "resourceOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the route.</p>"
+        },
+        "version": {
+          "shape": "Long",
+          "documentation": "<p>The version of the resource. Resources are created at version 1, and this version is incremented each time that they're updated.</p>"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The virtual router that the route is associated with.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a route returned by a list operation.</p>"
+    },
+    "DeleteVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualNodeName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to delete the virtual node in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual node to delete.</p>",
+          "location": "uri",
+          "locationName": "virtualNodeName"
+        }
+      },
+      "documentation": ""
+    },
+    "RouteData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "routeName",
+        "spec",
+        "status",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the route resides in.</p>"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata",
+          "documentation": "<p>The associated metadata for the route.</p>"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the route.</p>"
+        },
+        "spec": {
+          "shape": "RouteSpec",
+          "documentation": "<p>The specifications of the route.</p>"
+        },
+        "status": {
+          "shape": "RouteStatus",
+          "documentation": "<p>The status of the route.</p>"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The virtual router that the route is associated with.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a route returned by a describe operation.</p>"
+    },
+    "RouteStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "InternalServerErrorException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "documentation": "<p>The request processing has failed because of an unknown error, exception, or\n         failure.</p>",
+      "exception": true,
+      "error": {
+        "code": "InternalServerErrorException",
+        "httpStatusCode": 500,
+        "fault": true
+      }
+    },
+    "HeaderName": {
+      "type": "string",
+      "min": 1,
+      "max": 50
+    },
+    "TagList": {
+      "type": "list",
+      "member": {
+        "shape": "TagRef"
+      },
+      "min": 0,
+      "max": 50
+    },
+    "GrpcRetryPolicyEvent": {
+      "type": "string",
+      "enum": [
+        "cancelled",
+        "deadline-exceeded",
+        "internal",
+        "resource-exhausted",
+        "unavailable"
+      ]
+    },
+    "TlsValidationContextAcmTrust": {
+      "type": "structure",
+      "required": [
+        "certificateAuthorityArns"
+      ],
+      "members": {
+        "certificateAuthorityArns": {
+          "shape": "CertificateAuthorityArns",
+          "documentation": "<p>One or more ACM Amazon Resource Name (ARN)s.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a TLS validation context trust for an AWS Certicate Manager (ACM)\n         certificate.</p>"
+    },
+    "ForbiddenException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "documentation": "<p>You don't have permissions to perform this action.</p>",
+      "exception": true,
+      "error": {
+        "code": "ForbiddenException",
+        "httpStatusCode": 403,
+        "senderFault": true
+      }
+    },
+    "HeaderMatchMethod": {
+      "type": "structure",
+      "members": {
+        "exact": {
+          "shape": "HeaderMatch",
+          "documentation": "<p>The value sent by the client must match the specified value exactly.</p>"
+        },
+        "prefix": {
+          "shape": "HeaderMatch",
+          "documentation": "<p>The value sent by the client must begin with the specified characters.</p>"
+        },
+        "range": {
+          "shape": "MatchRange",
+          "documentation": "<p>An object that represents the range of values to match on.</p>"
+        },
+        "regex": {
+          "shape": "HeaderMatch",
+          "documentation": "<p>The value sent by the client must include the specified characters.</p>"
+        },
+        "suffix": {
+          "shape": "HeaderMatch",
+          "documentation": "<p>The value sent by the client must end with the specified characters.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the method and value to match with the header value sent in a\n         request. Specify one match method.</p>"
+    },
+    "DeleteMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData",
+          "documentation": "<p>The service mesh that was deleted.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "mesh"
+    },
+    "VirtualGatewayClientPolicyTls": {
+      "type": "structure",
+      "required": [
+        "validation"
+      ],
+      "members": {
+        "enforce": {
+          "shape": "Boolean",
+          "box": true
+        },
+        "ports": {
+          "shape": "PortSet"
+        },
+        "validation": {
+          "shape": "VirtualGatewayTlsValidationContext"
+        }
+      }
+    },
+    "EgressFilterType": {
+      "type": "string",
+      "enum": [
+        "ALLOW_ALL",
+        "DROP_ALL"
+      ]
+    },
+    "DurationValue": {
+      "type": "long",
+      "box": true,
+      "min": 0
+    },
+    "Hostname": {
+      "type": "string"
+    },
+    "VirtualGatewayStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualGatewayStatusCode"
+        }
+      }
+    },
+    "GatewayRouteStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "GatewayRouteStatusCode"
+        }
+      }
+    },
+    "VirtualGatewayListeners": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualGatewayListener"
+      },
+      "min": 0,
+      "max": 1
+    },
+    "CreateVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "ListVirtualGatewaysOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateways"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String"
+        },
+        "virtualGateways": {
+          "shape": "VirtualGatewayList"
+        }
+      }
+    },
+    "VirtualGatewayTlsValidationContext": {
+      "type": "structure",
+      "required": [
+        "trust"
+      ],
+      "members": {
+        "trust": {
+          "shape": "VirtualGatewayTlsValidationContextTrust"
+        }
+      }
+    },
+    "VirtualServiceProvider": {
+      "type": "structure",
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeServiceProvider",
+          "documentation": "<p>The virtual node associated with a virtual service.</p>"
+        },
+        "virtualRouter": {
+          "shape": "VirtualRouterServiceProvider",
+          "documentation": "<p>The virtual router associated with a virtual service.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the provider for a virtual service.</p>"
+    },
+    "GrpcRouteMatch": {
+      "type": "structure",
+      "members": {
+        "metadata": {
+          "shape": "GrpcRouteMetadataList",
+          "documentation": "<p>An object that represents the data to match from the request.</p>"
+        },
+        "methodName": {
+          "shape": "MethodName",
+          "documentation": "<p>The method name to match from the request. If you specify a name, you must also specify\n         a <code>serviceName</code>.</p>"
+        },
+        "serviceName": {
+          "shape": "ServiceName",
+          "documentation": "<p>The fully qualified domain name for the service to match from the request.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the criteria for determining a request match.</p>"
+    },
+    "AwsCloudMapServiceDiscovery": {
+      "type": "structure",
+      "required": [
+        "namespaceName",
+        "serviceName"
+      ],
+      "members": {
+        "attributes": {
+          "shape": "AwsCloudMapInstanceAttributes",
+          "documentation": "<p>A string map that contains attributes with values that you can use to filter instances\n         by any custom attribute that you specified when you registered the instance. Only instances\n         that match all of the specified key/value pairs will be returned.</p>"
+        },
+        "namespaceName": {
+          "shape": "AwsCloudMapName",
+          "documentation": "<p>The name of the AWS Cloud Map namespace to use.</p>"
+        },
+        "serviceName": {
+          "shape": "AwsCloudMapName",
+          "documentation": "<p>The name of the AWS Cloud Map service to use.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the AWS Cloud Map service discovery information for your virtual\n         node.</p>"
+    },
+    "UpdateVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData",
+          "documentation": "<p>A full description of the virtual service that was updated.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualService"
+    },
+    "MeshStatus": {
+      "type": "structure",
+      "members": {
+        "status": {
+          "shape": "MeshStatusCode",
+          "documentation": "<p>The current mesh status.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the status of a service mesh.</p>"
+    },
+    "CreateVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualNodeName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "documentation": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to create the virtual node in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then\n               the account that you specify must share the mesh with your account before you can create \n             the resource in the service mesh. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualNodeSpec",
+          "documentation": "<p>The virtual node specification to apply.</p>"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name to use for the virtual node.</p>"
+        }
+      },
+      "documentation": ""
+    },
+    "NotFoundException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "documentation": "<p>The specified resource doesn't exist. Check your request syntax and try again.</p>",
+      "exception": true,
+      "error": {
+        "code": "NotFoundException",
+        "httpStatusCode": 404,
+        "senderFault": true
+      }
+    },
+    "RouteSpec": {
+      "type": "structure",
+      "members": {
+        "grpcRoute": {
+          "shape": "GrpcRoute",
+          "documentation": "<p>An object that represents the specification of a gRPC route.</p>"
+        },
+        "http2Route": {
+          "shape": "HttpRoute",
+          "documentation": "<p>An object that represents the specification of an HTTP/2 route.</p>"
+        },
+        "httpRoute": {
+          "shape": "HttpRoute",
+          "documentation": "<p>An object that represents the specification of an HTTP route.</p>"
+        },
+        "priority": {
+          "shape": "RoutePriority",
+          "documentation": "<p>The priority for the route. Routes are matched based on the specified value, where 0 is\n         the highest priority.</p>"
+        },
+        "tcpRoute": {
+          "shape": "TcpRoute",
+          "documentation": "<p>An object that represents the specification of a TCP route.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a route specification. Specify one route type.</p>"
+    },
+    "GatewayRouteRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "gatewayRouteName",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "gatewayRouteName": {
+          "shape": "ResourceName"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "VirtualGatewayListenerTlsAcmCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateArn"
+      ],
+      "members": {
+        "certificateArn": {
+          "shape": "Arn"
+        }
+      }
+    },
+    "ListGatewayRoutesOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoutes"
+      ],
+      "members": {
+        "gatewayRoutes": {
+          "shape": "GatewayRouteList"
+        },
+        "nextToken": {
+          "shape": "String"
+        }
+      }
+    },
+    "CreateVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData",
+          "documentation": "<p>The full description of your virtual service following the create call.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualService"
+    },
+    "FileAccessLog": {
+      "type": "structure",
+      "required": [
+        "path"
+      ],
+      "members": {
+        "path": {
+          "shape": "FilePath",
+          "documentation": "<p>The file path to write access logs to. You can use <code>/dev/stdout</code> to send\n         access logs to standard out and configure your Envoy container to use a log driver, such as\n            <code>awslogs</code>, to export the access logs to a log storage service such as Amazon\n         CloudWatch Logs. You can also specify a path in the Envoy container's file system to write\n         the files to disk.</p>\n         <note>\n            <p>The Envoy process must have write permissions to the path that you specify here.\n            Otherwise, Envoy fails to bootstrap properly.</p>\n         </note>"
+        }
+      },
+      "documentation": "<p>An object that represents an access log file.</p>"
+    },
+    "VirtualRouterServiceProvider": {
+      "type": "structure",
+      "required": [
+        "virtualRouterName"
+      ],
+      "members": {
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router that is acting as a service provider.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a virtual node service provider.</p>"
+    },
+    "HttpTimeout": {
+      "type": "structure",
+      "members": {
+        "idle": {
+          "shape": "Duration"
+        },
+        "perRequest": {
+          "shape": "Duration"
+        }
+      }
+    },
+    "DeleteVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualServiceName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to delete the virtual service in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "documentation": "<p>The name of the virtual service to delete.</p>",
+          "location": "uri",
+          "locationName": "virtualServiceName"
+        }
+      },
+      "documentation": ""
+    },
+    "TlsValidationContext": {
+      "type": "structure",
+      "required": [
+        "trust"
+      ],
+      "members": {
+        "trust": {
+          "shape": "TlsValidationContextTrust",
+          "documentation": "<p>A reference to an object that represents a TLS validation context trust.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a Transport Layer Security (TLS) validation context.</p>"
+    },
+    "GatewayRouteStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "DeleteVirtualRouterOutput": {
+      "type": "structure",
+      "required": [
+        "virtualRouter"
+      ],
+      "members": {
+        "virtualRouter": {
+          "shape": "VirtualRouterData",
+          "documentation": "<p>The virtual router that was deleted.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualRouter"
+    },
+    "DescribeVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "GrpcGatewayRouteAction": {
+      "type": "structure",
+      "required": [
+        "target"
+      ],
+      "members": {
+        "target": {
+          "shape": "GatewayRouteTarget"
+        }
+      }
+    },
+    "DeleteVirtualNodeOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNode"
+      ],
+      "members": {
+        "virtualNode": {
+          "shape": "VirtualNodeData",
+          "documentation": "<p>The virtual node that was deleted.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualNode"
+    },
+    "UpdateVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualNodeName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "documentation": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual node resides in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualNodeSpec",
+          "documentation": "<p>The new virtual node specification to apply. This overwrites the existing data.</p>"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual node to update.</p>",
+          "location": "uri",
+          "locationName": "virtualNodeName"
+        }
+      },
+      "documentation": ""
+    },
+    "ListenerTls": {
+      "type": "structure",
+      "required": [
+        "certificate",
+        "mode"
+      ],
+      "members": {
+        "certificate": {
+          "shape": "ListenerTlsCertificate",
+          "documentation": "<p>A reference to an object that represents a listener's TLS certificate.</p>"
+        },
+        "mode": {
+          "shape": "ListenerTlsMode",
+          "documentation": "<p>Specify one of the following modes.</p>\n         <ul>\n            <li>\n               <p>\n                  <b/>STRICT – Listener only accepts connections with TLS\n               enabled. </p>\n            </li>\n            <li>\n               <p>\n                  <b/>PERMISSIVE – Listener accepts connections with or\n               without TLS enabled.</p>\n            </li>\n            <li>\n               <p>\n                  <b/>DISABLED – Listener only accepts connections without\n               TLS. </p>\n            </li>\n         </ul>"
+        }
+      },
+      "documentation": "<p>An object that represents the Transport Layer Security (TLS) properties for a listener.</p>"
+    },
+    "DeleteMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to delete.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        }
+      },
+      "documentation": ""
+    },
+    "TcpRetryPolicyEvents": {
+      "type": "list",
+      "member": {
+        "shape": "TcpRetryPolicyEvent"
+      },
+      "min": 1,
+      "max": 1
+    },
+    "CreateVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualServiceName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "documentation": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to create the virtual service in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then\n               the account that you specify must share the mesh with your account before you can create \n             the resource in the service mesh. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualServiceSpec",
+          "documentation": "<p>The virtual service specification to apply.</p>"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "documentation": "<p>The name to use for the virtual service.</p>"
+        }
+      },
+      "documentation": ""
+    },
+    "UpdateVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "documentation": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual router resides in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualRouterSpec",
+          "documentation": "<p>The new virtual router specification to apply. This overwrites the existing data.</p>"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router to update.</p>",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      },
+      "documentation": ""
+    },
+    "HttpGatewayRouteAction": {
+      "type": "structure",
+      "required": [
+        "target"
+      ],
+      "members": {
+        "target": {
+          "shape": "GatewayRouteTarget"
+        }
+      }
+    },
+    "GrpcGatewayRouteMatch": {
+      "type": "structure",
+      "members": {
+        "serviceName": {
+          "shape": "ServiceName"
+        }
+      }
+    },
+    "GrpcRetryPolicyEvents": {
+      "type": "list",
+      "member": {
+        "shape": "GrpcRetryPolicyEvent"
+      },
+      "min": 1,
+      "max": 5
+    },
+    "VirtualGatewayStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "ServiceUnavailableException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "documentation": "<p>The request has failed due to a temporary failure of the service.</p>",
+      "exception": true,
+      "error": {
+        "code": "ServiceUnavailableException",
+        "httpStatusCode": 503,
+        "fault": true
+      }
+    },
+    "DescribeMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData",
+          "documentation": "<p>The full description of your service mesh.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "mesh"
+    },
+    "DeleteVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to delete the virtual router in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router to delete.</p>",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      },
+      "documentation": ""
+    },
+    "UpdateGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "DescribeRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the route resides in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the route to describe.</p>",
+          "location": "uri",
+          "locationName": "routeName"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router that the route is associated with.</p>",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      },
+      "documentation": ""
+    },
+    "DeleteRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData",
+          "documentation": "<p>The route that was deleted.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "route"
+    },
+    "Listeners": {
+      "type": "list",
+      "member": {
+        "shape": "Listener"
+      },
+      "min": 0,
+      "max": 1
+    },
+    "Backends": {
+      "type": "list",
+      "member": {
+        "shape": "Backend"
+      }
+    },
+    "PortProtocol": {
+      "type": "string",
+      "enum": [
+        "grpc",
+        "http",
+        "http2",
+        "tcp"
+      ]
+    },
+    "DeleteGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "VirtualGatewayList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualGatewayRef"
+      }
+    },
+    "VirtualNodeStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "ServiceName": {
+      "type": "string"
+    },
+    "UpdateVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "spec",
+        "virtualServiceName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "documentation": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual service resides in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "VirtualServiceSpec",
+          "documentation": "<p>The new virtual service specification to apply. This overwrites the existing\n         data.</p>"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "documentation": "<p>The name of the virtual service to update.</p>",
+          "location": "uri",
+          "locationName": "virtualServiceName"
+        }
+      },
+      "documentation": ""
+    },
+    "HealthCheckThreshold": {
+      "type": "integer",
+      "min": 2,
+      "max": 10
+    },
+    "UpdateRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData",
+          "documentation": "<p>A full description of the route that was updated.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "route"
+    },
+    "PercentInt": {
+      "type": "integer",
+      "min": 0,
+      "max": 100
+    },
+    "MethodName": {
+      "type": "string",
+      "min": 1,
+      "max": 50
+    },
+    "TagValue": {
+      "type": "string",
+      "min": 0,
+      "max": 256
+    },
+    "HttpRouteAction": {
+      "type": "structure",
+      "required": [
+        "weightedTargets"
+      ],
+      "members": {
+        "weightedTargets": {
+          "shape": "WeightedTargets",
+          "documentation": "<p>An object that represents the targets that traffic is routed to when a request matches the route.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the action to take if a match is determined.</p>"
+    },
+    "ListRoutesInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListRoutesLimit",
+          "documentation": "<p>The maximum number of results returned by <code>ListRoutes</code> in paginated output.\n         When you use this parameter, <code>ListRoutes</code> returns only <code>limit</code>\n         results in a single page along with a <code>nextToken</code> response element. You can see\n         the remaining results of the initial request by sending another <code>ListRoutes</code>\n         request with the returned <code>nextToken</code> value. This value can be between\n         1 and 100. If you don't use this parameter,\n            <code>ListRoutes</code> returns up to 100 results and a\n            <code>nextToken</code> value if applicable.</p>",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to list routes in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "documentation": "<p>The <code>nextToken</code> value returned from a previous paginated\n            <code>ListRoutes</code> request where <code>limit</code> was used and the results\n         exceeded the value of that parameter. Pagination continues from the end of the previous\n         results that returned the <code>nextToken</code> value.</p>",
+          "location": "querystring",
+          "locationName": "nextToken"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router to list routes in.</p>",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      },
+      "documentation": ""
+    },
+    "VirtualServiceRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualServiceName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn",
+          "documentation": "<p>The full Amazon Resource Name (ARN) for the virtual service.</p>"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual service resides in.</p>"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "resourceOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "version": {
+          "shape": "Long",
+          "documentation": "<p>The version of the resource. Resources are created at version 1, and this version is incremented each time that they're updated.</p>"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "documentation": "<p>The name of the virtual service.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a virtual service returned by a list operation.</p>"
+    },
+    "GrpcTimeout": {
+      "type": "structure",
+      "members": {
+        "idle": {
+          "shape": "Duration"
+        },
+        "perRequest": {
+          "shape": "Duration"
+        }
+      }
+    },
+    "VirtualNodeStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualNodeStatusCode",
+          "documentation": "<p>The current status of the virtual node.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the current status of the virtual node.</p>"
+    },
+    "VirtualRouterRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualRouterName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn",
+          "documentation": "<p>The full Amazon Resource Name (ARN) for the virtual router.</p>"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual router resides in.</p>"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "resourceOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "version": {
+          "shape": "Long",
+          "documentation": "<p>The version of the resource. Resources are created at version 1, and this version is incremented each time that they're updated.</p>"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a virtual router returned by a list operation.</p>"
+    },
+    "VirtualServiceData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status",
+        "virtualServiceName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual service resides in.</p>"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata"
+        },
+        "spec": {
+          "shape": "VirtualServiceSpec",
+          "documentation": "<p>The specifications of the virtual service.</p>"
+        },
+        "status": {
+          "shape": "VirtualServiceStatus",
+          "documentation": "<p>The current status of the virtual service.</p>"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "documentation": "<p>The name of the virtual service.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a virtual service returned by a describe operation.</p>"
+    },
+    "HttpRouteHeader": {
+      "type": "structure",
+      "required": [
+        "name"
+      ],
+      "members": {
+        "invert": {
+          "shape": "Boolean",
+          "documentation": "<p>Specify <code>True</code> to match anything except the match criteria. The default value is <code>False</code>.</p>"
+        },
+        "match": {
+          "shape": "HeaderMatchMethod",
+          "documentation": "<p>The <code>HeaderMatchMethod</code> object.</p>"
+        },
+        "name": {
+          "shape": "HeaderName",
+          "documentation": "<p>A name for the HTTP header in the client request that will be matched on.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the HTTP header in the request.</p>"
+    },
+    "FilePath": {
+      "type": "string",
+      "min": 1,
+      "max": 255
+    },
+    "AwsCloudMapInstanceAttributes": {
+      "type": "list",
+      "member": {
+        "shape": "AwsCloudMapInstanceAttribute"
+      }
+    },
+    "VirtualNodeRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualNodeName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn",
+          "documentation": "<p>The full Amazon Resource Name (ARN) for the virtual node.</p>"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual node resides in.</p>"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "resourceOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "version": {
+          "shape": "Long",
+          "documentation": "<p>The version of the resource. Resources are created at version 1, and this version is incremented each time that they're updated.</p>"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual node.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a virtual node returned by a list operation.</p>"
+    },
+    "CreateMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "documentation": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name to use for the service mesh.</p>"
+        },
+        "spec": {
+          "shape": "MeshSpec",
+          "documentation": "<p>The service mesh specification to apply.</p>"
+        }
+      },
+      "documentation": ""
+    },
+    "GrpcRouteAction": {
+      "type": "structure",
+      "required": [
+        "weightedTargets"
+      ],
+      "members": {
+        "weightedTargets": {
+          "shape": "WeightedTargets",
+          "documentation": "<p>An object that represents the targets that traffic is routed to when a request matches the route.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the action to take if a match is determined.</p>"
+    },
+    "VirtualGatewayTlsValidationContextFileTrust": {
+      "type": "structure",
+      "required": [
+        "certificateChain"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath"
+        }
+      }
+    },
+    "LimitExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "documentation": "<p>You have exceeded a service limit for your account. For more information, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/service-quotas.html\">Service\n            Limits</a> in the <i>AWS App Mesh User Guide</i>.</p>",
+      "exception": true,
+      "error": {
+        "code": "LimitExceededException",
+        "httpStatusCode": 400,
+        "senderFault": true
+      }
+    },
+    "UpdateMeshOutput": {
+      "type": "structure",
+      "required": [
+        "mesh"
+      ],
+      "members": {
+        "mesh": {
+          "shape": "MeshData"
+        }
+      },
+      "documentation": "",
+      "payload": "mesh"
+    },
+    "GrpcRouteMetadataMatchMethod": {
+      "type": "structure",
+      "members": {
+        "exact": {
+          "shape": "HeaderMatch",
+          "documentation": "<p>The value sent by the client must match the specified value exactly.</p>"
+        },
+        "prefix": {
+          "shape": "HeaderMatch",
+          "documentation": "<p>The value sent by the client must begin with the specified characters.</p>"
+        },
+        "range": {
+          "shape": "MatchRange",
+          "documentation": "<p>An object that represents the range of values to match on.</p>"
+        },
+        "regex": {
+          "shape": "HeaderMatch",
+          "documentation": "<p>The value sent by the client must include the specified characters.</p>"
+        },
+        "suffix": {
+          "shape": "HeaderMatch",
+          "documentation": "<p>The value sent by the client must end with the specified characters.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the match method. Specify one of the match values.</p>"
+    },
+    "DescribeVirtualServiceInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualServiceName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual service resides in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualServiceName": {
+          "shape": "ServiceName",
+          "documentation": "<p>The name of the virtual service to describe.</p>",
+          "location": "uri",
+          "locationName": "virtualServiceName"
+        }
+      },
+      "documentation": ""
+    },
+    "ListVirtualServicesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "AwsCloudMapInstanceAttribute": {
+      "type": "structure",
+      "required": [
+        "key",
+        "value"
+      ],
+      "members": {
+        "key": {
+          "shape": "AwsCloudMapInstanceAttributeKey",
+          "documentation": "<p>The name of an AWS Cloud Map service instance attribute key. Any AWS Cloud Map service\n         instance that contains the specified key and value is returned.</p>"
+        },
+        "value": {
+          "shape": "AwsCloudMapInstanceAttributeValue",
+          "documentation": "<p>The value of an AWS Cloud Map service instance attribute key. Any AWS Cloud Map service\n         instance that contains the specified key and value is returned.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the AWS Cloud Map attribute information for your virtual\n         node.</p>"
+    },
+    "VirtualGatewayListenerTlsMode": {
+      "type": "string",
+      "enum": [
+        "DISABLED",
+        "PERMISSIVE",
+        "STRICT"
+      ]
+    },
+    "VirtualServiceSpec": {
+      "type": "structure",
+      "members": {
+        "provider": {
+          "shape": "VirtualServiceProvider",
+          "documentation": "<p>The App Mesh object that is acting as the provider for a virtual service. You can specify\n         a single virtual node or virtual router.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the specification of a virtual service.</p>"
+    },
+    "VirtualGatewayTlsValidationContextAcmTrust": {
+      "type": "structure",
+      "required": [
+        "certificateAuthorityArns"
+      ],
+      "members": {
+        "certificateAuthorityArns": {
+          "shape": "VirtualGatewayCertificateAuthorityArns"
+        }
+      }
+    },
+    "VirtualGatewayAccessLog": {
+      "type": "structure",
+      "members": {
+        "file": {
+          "shape": "VirtualGatewayFileAccessLog"
+        }
+      }
+    },
+    "MatchRange": {
+      "type": "structure",
+      "required": [
+        "end",
+        "start"
+      ],
+      "members": {
+        "end": {
+          "shape": "Long",
+          "documentation": "<p>The end of the range.</p>"
+        },
+        "start": {
+          "shape": "Long",
+          "documentation": "<p>The start of the range.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the range of values to match on. The first character of the range is included in the range, though the last character is not. For example, if the range specified were 1-100, only values 1-99 would be matched.</p>"
+    },
+    "ListVirtualRoutersLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "HealthCheckIntervalMillis": {
+      "type": "long",
+      "box": true,
+      "min": 5000,
+      "max": 300000
+    },
+    "VirtualRouterList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualRouterRef"
+      }
+    },
+    "Arn": {
+      "type": "string"
+    },
+    "TcpRoute": {
+      "type": "structure",
+      "required": [
+        "action"
+      ],
+      "members": {
+        "action": {
+          "shape": "TcpRouteAction",
+          "documentation": "<p>The action to take if a match is determined.</p>"
+        },
+        "timeout": {
+          "shape": "TcpTimeout",
+          "tags": [
+            "preview"
+          ]
+        }
+      },
+      "documentation": "<p>An object that represents a TCP route type.</p>"
+    },
+    "VirtualNodeList": {
+      "type": "list",
+      "member": {
+        "shape": "VirtualNodeRef"
+      }
+    },
+    "UpdateVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "ListVirtualRoutersInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualRoutersLimit",
+          "documentation": "<p>The maximum number of results returned by <code>ListVirtualRouters</code> in paginated\n         output. When you use this parameter, <code>ListVirtualRouters</code> returns only\n            <code>limit</code> results in a single page along with a <code>nextToken</code> response\n         element. You can see the remaining results of the initial request by sending another\n            <code>ListVirtualRouters</code> request with the returned <code>nextToken</code> value.\n         This value can be between 1 and 100. If you don't use this\n         parameter, <code>ListVirtualRouters</code> returns up to 100 results and\n         a <code>nextToken</code> value if applicable.</p>",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to list virtual routers in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "documentation": "<p>The <code>nextToken</code> value returned from a previous paginated\n            <code>ListVirtualRouters</code> request where <code>limit</code> was used and the\n         results exceeded the value of that parameter. Pagination continues from the end of the\n         previous results that returned the <code>nextToken</code> value.</p>",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      },
+      "documentation": ""
+    },
+    "DurationUnit": {
+      "type": "string",
+      "enum": [
+        "ms",
+        "s"
+      ]
+    },
+    "RoutePriority": {
+      "type": "integer",
+      "box": true,
+      "min": 0,
+      "max": 1000
+    },
+    "ListVirtualServicesInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualServicesLimit",
+          "documentation": "<p>The maximum number of results returned by <code>ListVirtualServices</code> in paginated\n         output. When you use this parameter, <code>ListVirtualServices</code> returns only\n            <code>limit</code> results in a single page along with a <code>nextToken</code> response\n         element. You can see the remaining results of the initial request by sending another\n            <code>ListVirtualServices</code> request with the returned <code>nextToken</code> value.\n         This value can be between 1 and 100. If you don't use this\n         parameter, <code>ListVirtualServices</code> returns up to 100 results and\n         a <code>nextToken</code> value if applicable.</p>",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to list virtual services in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "documentation": "<p>The <code>nextToken</code> value returned from a previous paginated\n            <code>ListVirtualServices</code> request where <code>limit</code> was used and the\n         results exceeded the value of that parameter. Pagination continues from the end of the\n         previous results that returned the <code>nextToken</code> value.</p>",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      },
+      "documentation": ""
+    },
+    "AccessLog": {
+      "type": "structure",
+      "members": {
+        "file": {
+          "shape": "FileAccessLog",
+          "documentation": "<p>The file object to send virtual node access logs to.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the access logging information for a virtual node.</p>"
+    },
+    "ListVirtualNodesInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualNodesLimit",
+          "documentation": "<p>The maximum number of results returned by <code>ListVirtualNodes</code> in paginated\n         output. When you use this parameter, <code>ListVirtualNodes</code> returns only\n            <code>limit</code> results in a single page along with a <code>nextToken</code> response\n         element. You can see the remaining results of the initial request by sending another\n            <code>ListVirtualNodes</code> request with the returned <code>nextToken</code> value.\n         This value can be between 1 and 100. If you don't use this\n         parameter, <code>ListVirtualNodes</code> returns up to 100 results and a\n            <code>nextToken</code> value if applicable.</p>",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to list virtual nodes in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "documentation": "<p>The <code>nextToken</code> value returned from a previous paginated\n            <code>ListVirtualNodes</code> request where <code>limit</code> was used and the results\n         exceeded the value of that parameter. Pagination continues from the end of the previous\n         results that returned the <code>nextToken</code> value.</p>",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      },
+      "documentation": ""
+    },
+    "VirtualGatewayClientPolicy": {
+      "type": "structure",
+      "members": {
+        "tls": {
+          "shape": "VirtualGatewayClientPolicyTls"
+        }
+      }
+    },
+    "ListVirtualNodesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "HealthCheckTimeoutMillis": {
+      "type": "long",
+      "box": true,
+      "min": 2000,
+      "max": 60000
+    },
+    "ResourceName": {
+      "type": "string",
+      "min": 1,
+      "max": 255
+    },
+    "TooManyRequestsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "shape": "String"
+        }
+      },
+      "documentation": "<p>The maximum request rate permitted by the App Mesh APIs has been exceeded for your\n         account. For best results, use an increasing or variable sleep interval between\n         requests.</p>",
+      "exception": true,
+      "error": {
+        "code": "TooManyRequestsException",
+        "httpStatusCode": 429,
+        "senderFault": true
+      }
+    },
+    "Timestamp": {
+      "type": "timestamp"
+    },
+    "VirtualGatewayLogging": {
+      "type": "structure",
+      "members": {
+        "accessLog": {
+          "shape": "VirtualGatewayAccessLog"
+        }
+      }
+    },
+    "HeaderMatch": {
+      "type": "string",
+      "min": 1,
+      "max": 255
+    },
+    "AccountId": {
+      "type": "string",
+      "min": 12,
+      "max": 12
+    },
+    "GatewayRouteTarget": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "GatewayRouteVirtualService"
+        }
+      }
+    },
+    "Duration": {
+      "type": "structure",
+      "members": {
+        "unit": {
+          "shape": "DurationUnit",
+          "documentation": "<p>A unit of time.</p>"
+        },
+        "value": {
+          "shape": "DurationValue",
+          "documentation": "<p>A number of time units.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a duration of time.</p>"
+    },
+    "DescribeRouteOutput": {
+      "type": "structure",
+      "required": [
+        "route"
+      ],
+      "members": {
+        "route": {
+          "shape": "RouteData",
+          "documentation": "<p>The full description of your route.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "route"
+    },
+    "HttpRouteMatch": {
+      "type": "structure",
+      "required": [
+        "prefix"
+      ],
+      "members": {
+        "headers": {
+          "shape": "HttpRouteHeaders",
+          "documentation": "<p>An object that represents the client request headers to match on.</p>"
+        },
+        "method": {
+          "shape": "HttpMethod",
+          "documentation": "<p>The client request method to match on. Specify only one.</p>"
+        },
+        "prefix": {
+          "shape": "String",
+          "documentation": "<p>Specifies the path to match requests with. This parameter must always start with\n            <code>/</code>, which by itself matches all requests to the virtual service name. You\n         can also match for path-based routing of requests. For example, if your virtual service\n         name is <code>my-service.local</code> and you want the route to match requests to\n            <code>my-service.local/metrics</code>, your prefix should be\n         <code>/metrics</code>.</p>"
+        },
+        "scheme": {
+          "shape": "HttpScheme",
+          "documentation": "<p>The client request scheme to match on. Specify only one.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the requirements for a route to match HTTP requests for a\n         virtual router.</p>"
+    },
+    "TagRef": {
+      "type": "structure",
+      "required": [
+        "key"
+      ],
+      "members": {
+        "key": {
+          "shape": "TagKey",
+          "documentation": "<p>One part of a key-value pair that make up a tag. A <code>key</code> is a general label\n         that acts like a category for more specific tag values.</p>"
+        },
+        "value": {
+          "shape": "TagValue",
+          "documentation": "<p>The optional part of a key-value pair that make up a tag. A <code>value</code> acts as a\n         descriptor within a tag category (key).</p>"
+        }
+      },
+      "documentation": "<p>Optional metadata that you apply to a resource to assist with categorization and\n         organization. Each tag consists of a key and an optional value, both of which you define.\n         Tag keys can have a maximum character length of 128 characters, and tag values can have\n            a maximum length of 256 characters.</p>"
+    },
+    "MeshRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn",
+          "documentation": "<p>The full Amazon Resource Name (ARN) of the service mesh.</p>"
+        },
+        "createdAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp",
+          "documentation": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh.</p>"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "resourceOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+        },
+        "version": {
+          "shape": "Long",
+          "documentation": "<p>The version of the resource. Resources are created at version 1, and this version is incremented each time that they're updated.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a service mesh returned by a list operation.</p>"
+    },
+    "ListVirtualGatewaysLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "MeshStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    },
+    "MeshData": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "metadata",
+        "spec",
+        "status"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh.</p>"
+        },
+        "metadata": {
+          "shape": "ResourceMetadata",
+          "documentation": "<p>The associated metadata for the service mesh.</p>"
+        },
+        "spec": {
+          "shape": "MeshSpec",
+          "documentation": "<p>The associated specification for the service mesh.</p>"
+        },
+        "status": {
+          "shape": "MeshStatus",
+          "documentation": "<p>The status of the service mesh.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a service mesh returned by a describe operation.</p>"
+    },
+    "CreateGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "GatewayRouteList": {
+      "type": "list",
+      "member": {
+        "shape": "GatewayRouteRef"
+      }
+    },
+    "VirtualRouterStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "VirtualRouterStatusCode",
+          "documentation": "<p>The current status of the virtual router.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the status of a virtual router. </p>"
+    },
+    "TcpRouteAction": {
+      "type": "structure",
+      "required": [
+        "weightedTargets"
+      ],
+      "members": {
+        "weightedTargets": {
+          "shape": "WeightedTargets",
+          "documentation": "<p>An object that represents the targets that traffic is routed to when a request matches the route.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the action to take if a match is determined.</p>"
+    },
+    "DeleteVirtualGatewayInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "DescribeVirtualNodeInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualNodeName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual node resides in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual node to describe.</p>",
+          "location": "uri",
+          "locationName": "virtualNodeName"
+        }
+      },
+      "documentation": ""
+    },
+    "RouteStatus": {
+      "type": "structure",
+      "required": [
+        "status"
+      ],
+      "members": {
+        "status": {
+          "shape": "RouteStatusCode",
+          "documentation": "<p>The current status for the route.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the current status of a route.</p>"
+    },
+    "Listener": {
+      "type": "structure",
+      "required": [
+        "portMapping"
+      ],
+      "members": {
+        "healthCheck": {
+          "shape": "HealthCheckPolicy",
+          "documentation": "<p>The health check information for the listener.</p>"
+        },
+        "portMapping": {
+          "shape": "PortMapping",
+          "documentation": "<p>The port mapping information for the listener.</p>"
+        },
+        "timeout": {
+          "shape": "ListenerTimeout",
+          "tags": [
+            "preview"
+          ]
+        },
+        "tls": {
+          "shape": "ListenerTls",
+          "documentation": "<p>A reference to an object that represents the Transport Layer Security (TLS) properties for a listener.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a listener for a virtual node.</p>"
+    },
+    "GrpcRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "GrpcRouteAction",
+          "documentation": "<p>An object that represents the action to take if a match is determined.</p>"
+        },
+        "match": {
+          "shape": "GrpcRouteMatch",
+          "documentation": "<p>An object that represents the criteria for determining a request match.</p>"
+        },
+        "retryPolicy": {
+          "shape": "GrpcRetryPolicy",
+          "documentation": "<p>An object that represents a retry policy.</p>"
+        },
+        "timeout": {
+          "shape": "GrpcTimeout",
+          "tags": [
+            "preview"
+          ]
+        }
+      },
+      "documentation": "<p>An object that represents a gRPC route type.</p>"
+    },
+    "ListRoutesLimit": {
+      "type": "integer",
+      "box": true,
+      "min": 1,
+      "max": 100
+    },
+    "ClientPolicyTls": {
+      "type": "structure",
+      "required": [
+        "validation"
+      ],
+      "members": {
+        "enforce": {
+          "shape": "Boolean",
+          "box": true,
+          "documentation": "<p>Whether the policy is enforced. The default is <code>True</code>, if a value isn't\n         specified.</p>"
+        },
+        "ports": {
+          "shape": "PortSet",
+          "documentation": "<p>One or more ports that the policy is enforced for.</p>"
+        },
+        "validation": {
+          "shape": "TlsValidationContext",
+          "documentation": "<p>A reference to an object that represents a TLS validation context.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a Transport Layer Security (TLS) client policy.</p>"
+    },
+    "VirtualGatewayTlsValidationContextTrust": {
+      "type": "structure",
+      "members": {
+        "acm": {
+          "shape": "VirtualGatewayTlsValidationContextAcmTrust"
+        },
+        "file": {
+          "shape": "VirtualGatewayTlsValidationContextFileTrust"
+        }
+      }
+    },
+    "DeleteVirtualServiceOutput": {
+      "type": "structure",
+      "required": [
+        "virtualService"
+      ],
+      "members": {
+        "virtualService": {
+          "shape": "VirtualServiceData",
+          "documentation": "<p>The virtual service that was deleted.</p>"
+        }
+      },
+      "documentation": "",
+      "payload": "virtualService"
+    },
+    "VirtualGatewayPortProtocol": {
+      "type": "string",
+      "enum": [
+        "grpc",
+        "http",
+        "http2"
+      ]
+    },
+    "VirtualNodeServiceProvider": {
+      "type": "structure",
+      "required": [
+        "virtualNodeName"
+      ],
+      "members": {
+        "virtualNodeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual node that is acting as a service provider.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a virtual node service provider.</p>"
+    },
+    "HttpGatewayRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "HttpGatewayRouteAction"
+        },
+        "match": {
+          "shape": "HttpGatewayRouteMatch"
+        }
+      }
+    },
+    "BackendDefaults": {
+      "type": "structure",
+      "members": {
+        "clientPolicy": {
+          "shape": "ClientPolicy",
+          "documentation": "<p>A reference to an object that represents a client policy.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the default properties for a backend.</p>"
+    },
+    "ListenerTlsFileCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateChain",
+        "privateKey"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath",
+          "documentation": "<p>The certificate chain for the certificate.</p>"
+        },
+        "privateKey": {
+          "shape": "FilePath",
+          "documentation": "<p>The private key for a certificate stored on the file system of the virtual node that the\n         proxy is running on.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a local file certificate.\n         The certificate must meet specific requirements and you must have proxy authorization enabled. For more information, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/tls.html#virtual-node-tls-prerequisites\">Transport Layer Security (TLS)</a>.</p>"
+    },
+    "HttpRetryPolicy": {
+      "type": "structure",
+      "required": [
+        "maxRetries",
+        "perRetryTimeout"
+      ],
+      "members": {
+        "httpRetryEvents": {
+          "shape": "HttpRetryPolicyEvents",
+          "documentation": "<p>Specify at least one of the following values.</p> \n         <ul>\n            <li>\n               <p>\n                  <b>server-error</b> – HTTP status codes 500, 501,\n                  502, 503, 504, 505, 506, 507, 508, 510, and 511</p>\n            </li>\n            <li>\n               <p>\n                  <b>gateway-error</b> – HTTP status codes 502,\n                  503, and 504</p>\n            </li>\n            <li>\n               <p>\n                  <b>client-error</b> – HTTP status code 409</p>\n            </li>\n            <li>\n               <p>\n                  <b>stream-error</b> – Retry on refused\n                  stream</p>\n            </li>\n         </ul>"
+        },
+        "maxRetries": {
+          "shape": "MaxRetries",
+          "documentation": "<p>The maximum number of retry attempts.</p>"
+        },
+        "perRetryTimeout": {
+          "shape": "Duration",
+          "documentation": "<p>An object that represents a duration of time.</p>"
+        },
+        "tcpRetryEvents": {
+          "shape": "TcpRetryPolicyEvents",
+          "documentation": "<p>Specify a valid value.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a retry policy. Specify at least one value for at least one of the types of <code>RetryEvents</code>, a value for <code>maxRetries</code>, and a value for <code>perRetryTimeout</code>.</p>"
+    },
+    "DescribeVirtualRouterInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "virtualRouterName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the virtual router resides in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router to describe.</p>",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      },
+      "documentation": ""
+    },
+    "RouteList": {
+      "type": "list",
+      "member": {
+        "shape": "RouteRef"
+      }
+    },
+    "UpdateGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "spec",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "idempotencyToken": true
+        },
+        "gatewayRouteName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "gatewayRouteName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "spec": {
+          "shape": "GatewayRouteSpec"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "ListVirtualGatewaysInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "limit": {
+          "shape": "ListVirtualGatewaysLimit",
+          "location": "querystring",
+          "locationName": "limit"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "nextToken": {
+          "shape": "String",
+          "location": "querystring",
+          "locationName": "nextToken"
+        }
+      }
+    },
+    "PortNumber": {
+      "type": "integer",
+      "min": 1,
+      "max": 65535
+    },
+    "TlsValidationContextFileTrust": {
+      "type": "structure",
+      "required": [
+        "certificateChain"
+      ],
+      "members": {
+        "certificateChain": {
+          "shape": "FilePath",
+          "documentation": "<p>The certificate trust chain for a certificate stored on the file system of the virtual\n         node that the proxy is running on.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents a Transport Layer Security (TLS) validation context trust for a local file.</p>"
+    },
+    "GrpcRouteMetadata": {
+      "type": "structure",
+      "required": [
+        "name"
+      ],
+      "members": {
+        "invert": {
+          "shape": "Boolean",
+          "documentation": "<p>Specify <code>True</code> to match anything except the match criteria. The default value is <code>False</code>.</p>"
+        },
+        "match": {
+          "shape": "GrpcRouteMetadataMatchMethod",
+          "documentation": "<p>An object that represents the data to match from the request.</p>"
+        },
+        "name": {
+          "shape": "HeaderName",
+          "documentation": "<p>The name of the route.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the match metadata for the route.</p>"
+    },
+    "CreateRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "documentation": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to create the route in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then\n               the account that you specify must share the mesh with your account before you can create \n             the resource in the service mesh. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name to use for the route.</p>"
+        },
+        "spec": {
+          "shape": "RouteSpec",
+          "documentation": "<p>The route specification to apply.</p>"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router in which to create the route. If the virtual router is in\n         a shared mesh, then you must be the owner of the virtual router resource.</p>",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      },
+      "documentation": ""
+    },
+    "VirtualGatewayCertificateAuthorityArns": {
+      "type": "list",
+      "member": {
+        "shape": "Arn"
+      },
+      "min": 1,
+      "max": 3
+    },
+    "WeightedTargets": {
+      "type": "list",
+      "member": {
+        "shape": "WeightedTarget"
+      },
+      "min": 1,
+      "max": 10
+    },
+    "HttpRouteHeaders": {
+      "type": "list",
+      "member": {
+        "shape": "HttpRouteHeader"
+      },
+      "min": 1,
+      "max": 10
+    },
+    "String": {
+      "type": "string"
+    },
+    "TcpTimeout": {
+      "type": "structure",
+      "members": {
+        "idle": {
+          "shape": "Duration"
+        }
+      }
+    },
+    "HttpScheme": {
+      "type": "string",
+      "enum": [
+        "http",
+        "https"
+      ]
+    },
+    "DeleteGatewayRouteInput": {
+      "type": "structure",
+      "required": [
+        "gatewayRouteName",
+        "meshName",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "gatewayRouteName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "gatewayRouteName"
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName",
+          "location": "uri",
+          "locationName": "virtualGatewayName"
+        }
+      }
+    },
+    "UpdateRouteInput": {
+      "type": "structure",
+      "required": [
+        "meshName",
+        "routeName",
+        "spec",
+        "virtualRouterName"
+      ],
+      "members": {
+        "clientToken": {
+          "shape": "String",
+          "documentation": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+          "idempotencyToken": true
+        },
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh that the route resides in.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        },
+        "routeName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the route to update.</p>",
+          "location": "uri",
+          "locationName": "routeName"
+        },
+        "spec": {
+          "shape": "RouteSpec",
+          "documentation": "<p>The new route specification to apply. This overwrites the existing data.</p>"
+        },
+        "virtualRouterName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the virtual router that the route is associated with.</p>",
+          "location": "uri",
+          "locationName": "virtualRouterName"
+        }
+      },
+      "documentation": ""
+    },
+    "HttpRoute": {
+      "type": "structure",
+      "required": [
+        "action",
+        "match"
+      ],
+      "members": {
+        "action": {
+          "shape": "HttpRouteAction",
+          "documentation": "<p>An object that represents the action to take if a match is determined.</p>"
+        },
+        "match": {
+          "shape": "HttpRouteMatch",
+          "documentation": "<p>An object that represents the criteria for determining a request match.</p>"
+        },
+        "retryPolicy": {
+          "shape": "HttpRetryPolicy",
+          "documentation": "<p>An object that represents a retry policy.</p>"
+        },
+        "timeout": {
+          "shape": "HttpTimeout",
+          "tags": [
+            "preview"
+          ]
+        }
+      },
+      "documentation": "<p>An object that represents an HTTP or HTTP/2 route type.</p>"
+    },
+    "DescribeMeshInput": {
+      "type": "structure",
+      "required": [
+        "meshName"
+      ],
+      "members": {
+        "meshName": {
+          "shape": "ResourceName",
+          "documentation": "<p>The name of the service mesh to describe.</p>",
+          "location": "uri",
+          "locationName": "meshName"
+        },
+        "meshOwner": {
+          "shape": "AccountId",
+          "documentation": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+          "location": "querystring",
+          "locationName": "meshOwner"
+        }
+      },
+      "documentation": ""
+    },
+    "VirtualGatewayRef": {
+      "type": "structure",
+      "required": [
+        "arn",
+        "createdAt",
+        "lastUpdatedAt",
+        "meshName",
+        "meshOwner",
+        "resourceOwner",
+        "version",
+        "virtualGatewayName"
+      ],
+      "members": {
+        "arn": {
+          "shape": "Arn"
+        },
+        "createdAt": {
+          "shape": "Timestamp"
+        },
+        "lastUpdatedAt": {
+          "shape": "Timestamp"
+        },
+        "meshName": {
+          "shape": "ResourceName"
+        },
+        "meshOwner": {
+          "shape": "AccountId"
+        },
+        "resourceOwner": {
+          "shape": "AccountId"
+        },
+        "version": {
+          "shape": "Long"
+        },
+        "virtualGatewayName": {
+          "shape": "ResourceName"
+        }
+      }
+    },
+    "MeshSpec": {
+      "type": "structure",
+      "members": {
+        "egressFilter": {
+          "shape": "EgressFilter",
+          "documentation": "<p>The egress filter rules for the service mesh.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the specification of a service mesh.</p>"
+    },
+    "DescribeVirtualGatewayOutput": {
+      "type": "structure",
+      "required": [
+        "virtualGateway"
+      ],
+      "members": {
+        "virtualGateway": {
+          "shape": "VirtualGatewayData"
+        }
+      },
+      "payload": "virtualGateway"
+    },
+    "DescribeGatewayRouteOutput": {
+      "type": "structure",
+      "required": [
+        "gatewayRoute"
+      ],
+      "members": {
+        "gatewayRoute": {
+          "shape": "GatewayRouteData"
+        }
+      },
+      "payload": "gatewayRoute"
+    },
+    "ServiceDiscovery": {
+      "type": "structure",
+      "members": {
+        "awsCloudMap": {
+          "shape": "AwsCloudMapServiceDiscovery",
+          "documentation": "<p>Specifies any AWS Cloud Map information for the virtual node.</p>"
+        },
+        "dns": {
+          "shape": "DnsServiceDiscovery",
+          "documentation": "<p>Specifies the DNS information for the virtual node.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents the service discovery information for a virtual node.</p>"
+    },
+    "ListVirtualNodesOutput": {
+      "type": "structure",
+      "required": [
+        "virtualNodes"
+      ],
+      "members": {
+        "nextToken": {
+          "shape": "String",
+          "documentation": "<p>The <code>nextToken</code> value to include in a future <code>ListVirtualNodes</code>\n         request. When the results of a <code>ListVirtualNodes</code> request exceed\n            <code>limit</code>, you can use this value to retrieve the next page of results. This\n         value is <code>null</code> when there are no more results to return.</p>"
+        },
+        "virtualNodes": {
+          "shape": "VirtualNodeList",
+          "documentation": "<p>The list of existing virtual nodes for the specified service mesh.</p>"
+        }
+      },
+      "documentation": ""
+    },
+    "ListenerTlsAcmCertificate": {
+      "type": "structure",
+      "required": [
+        "certificateArn"
+      ],
+      "members": {
+        "certificateArn": {
+          "shape": "Arn",
+          "documentation": "<p>The Amazon Resource Name (ARN) for the certificate. The certificate must meet specific requirements and you must have proxy authorization enabled. For more information, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/tls.html#virtual-node-tls-prerequisites\">Transport Layer Security (TLS)</a>.</p>"
+        }
+      },
+      "documentation": "<p>An object that represents an AWS Certicate Manager (ACM) certificate.</p>"
+    },
+    "TagKey": {
+      "type": "string",
+      "min": 1,
+      "max": 128
+    },
+    "VirtualServiceStatusCode": {
+      "type": "string",
+      "enum": [
+        "ACTIVE",
+        "DELETED",
+        "INACTIVE"
+      ]
+    }
+  }
+}

--- a/appmesh-preview/sdk/docs.json
+++ b/appmesh-preview/sdk/docs.json
@@ -1,0 +1,1550 @@
+{
+  "version": "2.0",
+  "service": "<p>AWS App Mesh is a service mesh based on the Envoy proxy that makes it easy to monitor and\n         control microservices. App Mesh standardizes how your microservices communicate, giving you\n         end-to-end visibility and helping to ensure high availability for your applications.</p>\n         <p>App Mesh gives you consistent visibility and network traffic controls for every\n         microservice in an application. You can use App Mesh with AWS Fargate, Amazon ECS, Amazon EKS,\n         Kubernetes on AWS, and Amazon EC2.</p>\n         <note>\n            <p>App Mesh supports microservice applications that use service discovery naming for their\n            components. For more information about service discovery on Amazon ECS, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-discovery.html\">Service Discovery</a> in the <i>Amazon Elastic Container Service Developer Guide</i>. Kubernetes\n               <code>kube-dns</code> and <code>coredns</code> are supported. For more information,\n            see <a href=\"https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/\">DNS\n               for Services and Pods</a> in the Kubernetes documentation.</p>\n         </note>",
+  "operations": {
+    "CreateGatewayRoute": null,
+    "CreateMesh": "<p>Creates a service mesh.</p>\n         <p> A service mesh is a logical boundary for network traffic between services that are\n         represented by resources within the mesh. After you create your service mesh, you can\n         create virtual services, virtual nodes, virtual routers, and routes to distribute traffic\n         between the applications in your mesh.</p>\n         <p>For more information about service meshes, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/meshes.html\">Service meshes</a>.</p>",
+    "CreateRoute": "<p>Creates a route that is associated with a virtual router.</p>\n         <p> You can route several different protocols and define a retry policy for a route.\n         Traffic can be routed to one or more virtual nodes.</p>\n         <p>For more information about routes, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/routes.html\">Routes</a>.</p>",
+    "CreateVirtualGateway": null,
+    "CreateVirtualNode": "<p>Creates a virtual node within a service mesh.</p>\n         <p> A virtual node acts as a logical pointer to a particular task group, such as an Amazon ECS\n         service or a Kubernetes deployment. When you create a virtual node, you can specify the\n         service discovery information for your task group, and whether the proxy running in a task\n         group will communicate with other proxies using Transport Layer Security (TLS).</p>\n         <p>You define a <code>listener</code> for any inbound traffic that your virtual node\n         expects. Any virtual service that your virtual node expects to communicate to is specified\n         as a <code>backend</code>.</p>\n         <p>The response metadata for your new virtual node contains the <code>arn</code> that is\n         associated with the virtual node. Set this value (either the full ARN or the truncated\n         resource name: for example, <code>mesh/default/virtualNode/simpleapp</code>) as the\n            <code>APPMESH_VIRTUAL_NODE_NAME</code> environment variable for your task group's Envoy\n         proxy container in your task definition or pod spec. This is then mapped to the\n            <code>node.id</code> and <code>node.cluster</code> Envoy parameters.</p>\n         <note>\n            <p>If you require your Envoy stats or tracing to use a different name, you can override\n            the <code>node.cluster</code> value that is set by\n               <code>APPMESH_VIRTUAL_NODE_NAME</code> with the\n               <code>APPMESH_VIRTUAL_NODE_CLUSTER</code> environment variable.</p>\n         </note>\n         <p>For more information about virtual nodes, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_nodes.html\">Virtual nodes</a>.</p>",
+    "CreateVirtualRouter": "<p>Creates a virtual router within a service mesh.</p>\n         <p>Specify a <code>listener</code> for any inbound traffic that your virtual router\n         receives. Create a virtual router for each protocol and port that you need to route.\n         Virtual routers handle traffic for one or more virtual services within your mesh. After you\n         create your virtual router, create and associate routes for your virtual router that direct\n         incoming requests to different virtual nodes.</p>\n         <p>For more information about virtual routers, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_routers.html\">Virtual routers</a>.</p>",
+    "CreateVirtualService": "<p>Creates a virtual service within a service mesh.</p>\n         <p>A virtual service is an abstraction of a real service that is provided by a virtual node\n         directly or indirectly by means of a virtual router. Dependent services call your virtual\n         service by its <code>virtualServiceName</code>, and those requests are routed to the\n         virtual node or virtual router that is specified as the provider for the virtual\n         service.</p>\n         <p>For more information about virtual services, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/virtual_services.html\">Virtual services</a>.</p>",
+    "DeleteGatewayRoute": null,
+    "DeleteMesh": "<p>Deletes an existing service mesh.</p>\n         <p>You must delete all resources (virtual services, routes, virtual routers, and virtual\n         nodes) in the service mesh before you can delete the mesh itself.</p>",
+    "DeleteRoute": "<p>Deletes an existing route.</p>",
+    "DeleteVirtualGateway": null,
+    "DeleteVirtualNode": "<p>Deletes an existing virtual node.</p>\n         <p>You must delete any virtual services that list a virtual node as a service provider\n         before you can delete the virtual node itself.</p>",
+    "DeleteVirtualRouter": "<p>Deletes an existing virtual router.</p>\n         <p>You must delete any routes associated with the virtual router before you can delete the\n         router itself.</p>",
+    "DeleteVirtualService": "<p>Deletes an existing virtual service.</p>",
+    "DescribeGatewayRoute": null,
+    "DescribeMesh": "<p>Describes an existing service mesh.</p>",
+    "DescribeRoute": "<p>Describes an existing route.</p>",
+    "DescribeVirtualGateway": null,
+    "DescribeVirtualNode": "<p>Describes an existing virtual node.</p>",
+    "DescribeVirtualRouter": "<p>Describes an existing virtual router.</p>",
+    "DescribeVirtualService": "<p>Describes an existing virtual service.</p>",
+    "ListGatewayRoutes": null,
+    "ListMeshes": "<p>Returns a list of existing service meshes.</p>",
+    "ListRoutes": "<p>Returns a list of existing routes in a service mesh.</p>",
+    "ListVirtualGateways": null,
+    "ListVirtualNodes": "<p>Returns a list of existing virtual nodes.</p>",
+    "ListVirtualRouters": "<p>Returns a list of existing virtual routers in a service mesh.</p>",
+    "ListVirtualServices": "<p>Returns a list of existing virtual services in a service mesh.</p>",
+    "UpdateGatewayRoute": null,
+    "UpdateMesh": "<p>Updates an existing service mesh.</p>",
+    "UpdateRoute": "<p>Updates an existing route for a specified service mesh and virtual router.</p>",
+    "UpdateVirtualGateway": null,
+    "UpdateVirtualNode": "<p>Updates an existing virtual node in a specified service mesh.</p>",
+    "UpdateVirtualRouter": "<p>Updates an existing virtual router in a specified service mesh.</p>",
+    "UpdateVirtualService": "<p>Updates an existing virtual service in a specified service mesh.</p>"
+  },
+  "shapes": {
+    "AccessLog": {
+      "base": "<p>An object that represents the access logging information for a virtual node.</p>",
+      "refs": {
+        "AccessLog$file": "<p>The file object to send virtual node access logs to.</p>"
+      }
+    },
+    "AccountId": {
+      "base": null,
+      "refs": { }
+    },
+    "Arn": {
+      "base": null,
+      "refs": { }
+    },
+    "AwsCloudMapInstanceAttribute": {
+      "base": "<p>An object that represents the AWS Cloud Map attribute information for your virtual\n         node.</p>",
+      "refs": {
+        "AwsCloudMapInstanceAttribute$key": "<p>The name of an AWS Cloud Map service instance attribute key. Any AWS Cloud Map service\n         instance that contains the specified key and value is returned.</p>",
+        "AwsCloudMapInstanceAttribute$value": "<p>The value of an AWS Cloud Map service instance attribute key. Any AWS Cloud Map service\n         instance that contains the specified key and value is returned.</p>"
+      }
+    },
+    "AwsCloudMapInstanceAttributeKey": {
+      "base": null,
+      "refs": { }
+    },
+    "AwsCloudMapInstanceAttributeValue": {
+      "base": null,
+      "refs": { }
+    },
+    "AwsCloudMapInstanceAttributes": {
+      "base": null,
+      "refs": {
+        "AwsCloudMapInstanceAttributes$member": null
+      }
+    },
+    "AwsCloudMapName": {
+      "base": null,
+      "refs": { }
+    },
+    "AwsCloudMapServiceDiscovery": {
+      "base": "<p>An object that represents the AWS Cloud Map service discovery information for your virtual\n         node.</p>",
+      "refs": {
+        "AwsCloudMapServiceDiscovery$attributes": "<p>A string map that contains attributes with values that you can use to filter instances\n         by any custom attribute that you specified when you registered the instance. Only instances\n         that match all of the specified key/value pairs will be returned.</p>",
+        "AwsCloudMapServiceDiscovery$namespaceName": "<p>The name of the AWS Cloud Map namespace to use.</p>",
+        "AwsCloudMapServiceDiscovery$serviceName": "<p>The name of the AWS Cloud Map service to use.</p>"
+      }
+    },
+    "Backend": {
+      "base": "<p>An object that represents the backends that a virtual node is expected to send outbound\n         traffic to. </p>",
+      "refs": {
+        "Backend$virtualService": "<p>Specifies a virtual service to use as a backend for a virtual node. </p>"
+      }
+    },
+    "BackendDefaults": {
+      "base": "<p>An object that represents the default properties for a backend.</p>",
+      "refs": {
+        "BackendDefaults$clientPolicy": "<p>A reference to an object that represents a client policy.</p>"
+      }
+    },
+    "Backends": {
+      "base": null,
+      "refs": {
+        "Backends$member": null
+      }
+    },
+    "BadRequestException": {
+      "base": "<p>The request syntax was malformed. Check your request syntax and try again.</p>",
+      "refs": { }
+    },
+    "Boolean": {
+      "base": null,
+      "refs": { }
+    },
+    "CertificateAuthorityArns": {
+      "base": null,
+      "refs": {
+        "CertificateAuthorityArns$member": null
+      }
+    },
+    "ClientPolicy": {
+      "base": "<p>An object that represents a client policy.</p>",
+      "refs": {
+        "ClientPolicy$tls": "<p>A reference to an object that represents a Transport Layer Security (TLS) client policy.</p>"
+      }
+    },
+    "ClientPolicyTls": {
+      "base": "<p>An object that represents a Transport Layer Security (TLS) client policy.</p>",
+      "refs": {
+        "ClientPolicyTls$enforce": "<p>Whether the policy is enforced. The default is <code>True</code>, if a value isn't\n         specified.</p>",
+        "ClientPolicyTls$ports": "<p>One or more ports that the policy is enforced for.</p>",
+        "ClientPolicyTls$validation": "<p>A reference to an object that represents a TLS validation context.</p>"
+      }
+    },
+    "ConflictException": {
+      "base": "<p>The request contains a client token that was used for a previous update resource call\n         with different specifications. Try the request again with a new client token.</p>",
+      "refs": { }
+    },
+    "CreateGatewayRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateGatewayRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateMeshInput": {
+      "base": "",
+      "refs": {
+        "CreateMeshInput$clientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+        "CreateMeshInput$meshName": "<p>The name to use for the service mesh.</p>",
+        "CreateMeshInput$spec": "<p>The service mesh specification to apply.</p>"
+      }
+    },
+    "CreateMeshOutput": {
+      "base": "",
+      "refs": {
+        "CreateMeshOutput$mesh": "<p>The full description of your service mesh following the create call.</p>"
+      }
+    },
+    "CreateRouteInput": {
+      "base": "",
+      "refs": {
+        "CreateRouteInput$clientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+        "CreateRouteInput$meshName": "<p>The name of the service mesh to create the route in.</p>",
+        "CreateRouteInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then\n               the account that you specify must share the mesh with your account before you can create \n             the resource in the service mesh. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "CreateRouteInput$routeName": "<p>The name to use for the route.</p>",
+        "CreateRouteInput$spec": "<p>The route specification to apply.</p>",
+        "CreateRouteInput$virtualRouterName": "<p>The name of the virtual router in which to create the route. If the virtual router is in\n         a shared mesh, then you must be the owner of the virtual router resource.</p>"
+      }
+    },
+    "CreateRouteOutput": {
+      "base": "",
+      "refs": {
+        "CreateRouteOutput$route": "<p>The full description of your mesh following the create call.</p>"
+      }
+    },
+    "CreateVirtualGatewayInput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateVirtualGatewayOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "CreateVirtualNodeInput": {
+      "base": "",
+      "refs": {
+        "CreateVirtualNodeInput$clientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+        "CreateVirtualNodeInput$meshName": "<p>The name of the service mesh to create the virtual node in.</p>",
+        "CreateVirtualNodeInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then\n               the account that you specify must share the mesh with your account before you can create \n             the resource in the service mesh. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "CreateVirtualNodeInput$spec": "<p>The virtual node specification to apply.</p>",
+        "CreateVirtualNodeInput$virtualNodeName": "<p>The name to use for the virtual node.</p>"
+      }
+    },
+    "CreateVirtualNodeOutput": {
+      "base": "",
+      "refs": {
+        "CreateVirtualNodeOutput$virtualNode": "<p>The full description of your virtual node following the create call.</p>"
+      }
+    },
+    "CreateVirtualRouterInput": {
+      "base": "",
+      "refs": {
+        "CreateVirtualRouterInput$clientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+        "CreateVirtualRouterInput$meshName": "<p>The name of the service mesh to create the virtual router in.</p>",
+        "CreateVirtualRouterInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then\n               the account that you specify must share the mesh with your account before you can create \n             the resource in the service mesh. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "CreateVirtualRouterInput$spec": "<p>The virtual router specification to apply.</p>",
+        "CreateVirtualRouterInput$virtualRouterName": "<p>The name to use for the virtual router.</p>"
+      }
+    },
+    "CreateVirtualRouterOutput": {
+      "base": "",
+      "refs": {
+        "CreateVirtualRouterOutput$virtualRouter": "<p>The full description of your virtual router following the create call.</p>"
+      }
+    },
+    "CreateVirtualServiceInput": {
+      "base": "",
+      "refs": {
+        "CreateVirtualServiceInput$clientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+        "CreateVirtualServiceInput$meshName": "<p>The name of the service mesh to create the virtual service in.</p>",
+        "CreateVirtualServiceInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then\n               the account that you specify must share the mesh with your account before you can create \n             the resource in the service mesh. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "CreateVirtualServiceInput$spec": "<p>The virtual service specification to apply.</p>",
+        "CreateVirtualServiceInput$virtualServiceName": "<p>The name to use for the virtual service.</p>"
+      }
+    },
+    "CreateVirtualServiceOutput": {
+      "base": "",
+      "refs": {
+        "CreateVirtualServiceOutput$virtualService": "<p>The full description of your virtual service following the create call.</p>"
+      }
+    },
+    "DeleteGatewayRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteGatewayRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteMeshInput": {
+      "base": "",
+      "refs": {
+        "DeleteMeshInput$meshName": "<p>The name of the service mesh to delete.</p>"
+      }
+    },
+    "DeleteMeshOutput": {
+      "base": "",
+      "refs": {
+        "DeleteMeshOutput$mesh": "<p>The service mesh that was deleted.</p>"
+      }
+    },
+    "DeleteRouteInput": {
+      "base": "",
+      "refs": {
+        "DeleteRouteInput$meshName": "<p>The name of the service mesh to delete the route in.</p>",
+        "DeleteRouteInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "DeleteRouteInput$routeName": "<p>The name of the route to delete.</p>",
+        "DeleteRouteInput$virtualRouterName": "<p>The name of the virtual router to delete the route in.</p>"
+      }
+    },
+    "DeleteRouteOutput": {
+      "base": "",
+      "refs": {
+        "DeleteRouteOutput$route": "<p>The route that was deleted.</p>"
+      }
+    },
+    "DeleteVirtualGatewayInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteVirtualGatewayOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DeleteVirtualNodeInput": {
+      "base": "",
+      "refs": {
+        "DeleteVirtualNodeInput$meshName": "<p>The name of the service mesh to delete the virtual node in.</p>",
+        "DeleteVirtualNodeInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "DeleteVirtualNodeInput$virtualNodeName": "<p>The name of the virtual node to delete.</p>"
+      }
+    },
+    "DeleteVirtualNodeOutput": {
+      "base": "",
+      "refs": {
+        "DeleteVirtualNodeOutput$virtualNode": "<p>The virtual node that was deleted.</p>"
+      }
+    },
+    "DeleteVirtualRouterInput": {
+      "base": "",
+      "refs": {
+        "DeleteVirtualRouterInput$meshName": "<p>The name of the service mesh to delete the virtual router in.</p>",
+        "DeleteVirtualRouterInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "DeleteVirtualRouterInput$virtualRouterName": "<p>The name of the virtual router to delete.</p>"
+      }
+    },
+    "DeleteVirtualRouterOutput": {
+      "base": "",
+      "refs": {
+        "DeleteVirtualRouterOutput$virtualRouter": "<p>The virtual router that was deleted.</p>"
+      }
+    },
+    "DeleteVirtualServiceInput": {
+      "base": "",
+      "refs": {
+        "DeleteVirtualServiceInput$meshName": "<p>The name of the service mesh to delete the virtual service in.</p>",
+        "DeleteVirtualServiceInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "DeleteVirtualServiceInput$virtualServiceName": "<p>The name of the virtual service to delete.</p>"
+      }
+    },
+    "DeleteVirtualServiceOutput": {
+      "base": "",
+      "refs": {
+        "DeleteVirtualServiceOutput$virtualService": "<p>The virtual service that was deleted.</p>"
+      }
+    },
+    "DescribeGatewayRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeGatewayRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeMeshInput": {
+      "base": "",
+      "refs": {
+        "DescribeMeshInput$meshName": "<p>The name of the service mesh to describe.</p>",
+        "DescribeMeshInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>"
+      }
+    },
+    "DescribeMeshOutput": {
+      "base": "",
+      "refs": {
+        "DescribeMeshOutput$mesh": "<p>The full description of your service mesh.</p>"
+      }
+    },
+    "DescribeRouteInput": {
+      "base": "",
+      "refs": {
+        "DescribeRouteInput$meshName": "<p>The name of the service mesh that the route resides in.</p>",
+        "DescribeRouteInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "DescribeRouteInput$routeName": "<p>The name of the route to describe.</p>",
+        "DescribeRouteInput$virtualRouterName": "<p>The name of the virtual router that the route is associated with.</p>"
+      }
+    },
+    "DescribeRouteOutput": {
+      "base": "",
+      "refs": {
+        "DescribeRouteOutput$route": "<p>The full description of your route.</p>"
+      }
+    },
+    "DescribeVirtualGatewayInput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeVirtualGatewayOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "DescribeVirtualNodeInput": {
+      "base": "",
+      "refs": {
+        "DescribeVirtualNodeInput$meshName": "<p>The name of the service mesh that the virtual node resides in.</p>",
+        "DescribeVirtualNodeInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "DescribeVirtualNodeInput$virtualNodeName": "<p>The name of the virtual node to describe.</p>"
+      }
+    },
+    "DescribeVirtualNodeOutput": {
+      "base": "",
+      "refs": {
+        "DescribeVirtualNodeOutput$virtualNode": "<p>The full description of your virtual node.</p>"
+      }
+    },
+    "DescribeVirtualRouterInput": {
+      "base": "",
+      "refs": {
+        "DescribeVirtualRouterInput$meshName": "<p>The name of the service mesh that the virtual router resides in.</p>",
+        "DescribeVirtualRouterInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "DescribeVirtualRouterInput$virtualRouterName": "<p>The name of the virtual router to describe.</p>"
+      }
+    },
+    "DescribeVirtualRouterOutput": {
+      "base": "",
+      "refs": {
+        "DescribeVirtualRouterOutput$virtualRouter": "<p>The full description of your virtual router.</p>"
+      }
+    },
+    "DescribeVirtualServiceInput": {
+      "base": "",
+      "refs": {
+        "DescribeVirtualServiceInput$meshName": "<p>The name of the service mesh that the virtual service resides in.</p>",
+        "DescribeVirtualServiceInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "DescribeVirtualServiceInput$virtualServiceName": "<p>The name of the virtual service to describe.</p>"
+      }
+    },
+    "DescribeVirtualServiceOutput": {
+      "base": "",
+      "refs": {
+        "DescribeVirtualServiceOutput$virtualService": "<p>The full description of your virtual service.</p>"
+      }
+    },
+    "DnsServiceDiscovery": {
+      "base": "<p>An object that represents the DNS service discovery information for your virtual\n         node.</p>",
+      "refs": {
+        "DnsServiceDiscovery$hostname": "<p>Specifies the DNS service discovery hostname for the virtual node. </p>"
+      }
+    },
+    "Duration": {
+      "base": "<p>An object that represents a duration of time.</p>",
+      "refs": {
+        "Duration$unit": "<p>A unit of time.</p>",
+        "Duration$value": "<p>A number of time units.</p>"
+      }
+    },
+    "DurationUnit": {
+      "base": null,
+      "refs": { }
+    },
+    "DurationValue": {
+      "base": null,
+      "refs": { }
+    },
+    "EgressFilter": {
+      "base": "<p>An object that represents the egress filter rules for a service mesh.</p>",
+      "refs": {
+        "EgressFilter$type": "<p>The egress filter type. By default, the type is <code>DROP_ALL</code>, which allows\n         egress only from virtual nodes to other defined resources in the service mesh (and any\n         traffic to <code>*.amazonaws.com</code> for AWS API calls). You can set the egress filter\n         type to <code>ALLOW_ALL</code> to allow egress to any endpoint inside or outside of the\n         service mesh.</p>"
+      }
+    },
+    "EgressFilterType": {
+      "base": null,
+      "refs": { }
+    },
+    "FileAccessLog": {
+      "base": "<p>An object that represents an access log file.</p>",
+      "refs": {
+        "FileAccessLog$path": "<p>The file path to write access logs to. You can use <code>/dev/stdout</code> to send\n         access logs to standard out and configure your Envoy container to use a log driver, such as\n            <code>awslogs</code>, to export the access logs to a log storage service such as Amazon\n         CloudWatch Logs. You can also specify a path in the Envoy container's file system to write\n         the files to disk.</p>\n         <note>\n            <p>The Envoy process must have write permissions to the path that you specify here.\n            Otherwise, Envoy fails to bootstrap properly.</p>\n         </note>"
+      }
+    },
+    "FilePath": {
+      "base": null,
+      "refs": { }
+    },
+    "ForbiddenException": {
+      "base": "<p>You don't have permissions to perform this action.</p>",
+      "refs": { }
+    },
+    "GatewayRouteData": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteList": {
+      "base": null,
+      "refs": {
+        "GatewayRouteList$member": null
+      }
+    },
+    "GatewayRouteRef": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteSpec": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteStatus": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteTarget": {
+      "base": null,
+      "refs": { }
+    },
+    "GatewayRouteVirtualService": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcGatewayRoute": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcGatewayRouteAction": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcGatewayRouteMatch": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcRetryPolicy": {
+      "base": "<p>An object that represents a retry policy. Specify at least one value for at least one of the types of <code>RetryEvents</code>, a value for <code>maxRetries</code>, and a value for <code>perRetryTimeout</code>.</p>",
+      "refs": {
+        "GrpcRetryPolicy$grpcRetryEvents": "<p>Specify at least one of the valid values.</p>",
+        "GrpcRetryPolicy$httpRetryEvents": "<p>Specify at least one of the following values.</p> \n         <ul>\n            <li>\n               <p>\n                  <b>server-error</b> – HTTP status codes 500, 501,\n                  502, 503, 504, 505, 506, 507, 508, 510, and 511</p>\n            </li>\n            <li>\n               <p>\n                  <b>gateway-error</b> – HTTP status codes 502,\n                  503, and 504</p>\n            </li>\n            <li>\n               <p>\n                  <b>client-error</b> – HTTP status code 409</p>\n            </li>\n            <li>\n               <p>\n                  <b>stream-error</b> – Retry on refused\n                  stream</p>\n            </li>\n         </ul>",
+        "GrpcRetryPolicy$maxRetries": "<p>The maximum number of retry attempts.</p>",
+        "GrpcRetryPolicy$perRetryTimeout": "<p>An object that represents a duration of time.</p>",
+        "GrpcRetryPolicy$tcpRetryEvents": "<p>Specify a valid value.</p>"
+      }
+    },
+    "GrpcRetryPolicyEvent": {
+      "base": null,
+      "refs": { }
+    },
+    "GrpcRetryPolicyEvents": {
+      "base": null,
+      "refs": {
+        "GrpcRetryPolicyEvents$member": null
+      }
+    },
+    "GrpcRoute": {
+      "base": "<p>An object that represents a gRPC route type.</p>",
+      "refs": {
+        "GrpcRoute$action": "<p>An object that represents the action to take if a match is determined.</p>",
+        "GrpcRoute$match": "<p>An object that represents the criteria for determining a request match.</p>",
+        "GrpcRoute$retryPolicy": "<p>An object that represents a retry policy.</p>"
+      }
+    },
+    "GrpcRouteAction": {
+      "base": "<p>An object that represents the action to take if a match is determined.</p>",
+      "refs": {
+        "GrpcRouteAction$weightedTargets": "<p>An object that represents the targets that traffic is routed to when a request matches the route.</p>"
+      }
+    },
+    "GrpcRouteMatch": {
+      "base": "<p>An object that represents the criteria for determining a request match.</p>",
+      "refs": {
+        "GrpcRouteMatch$metadata": "<p>An object that represents the data to match from the request.</p>",
+        "GrpcRouteMatch$methodName": "<p>The method name to match from the request. If you specify a name, you must also specify\n         a <code>serviceName</code>.</p>",
+        "GrpcRouteMatch$serviceName": "<p>The fully qualified domain name for the service to match from the request.</p>"
+      }
+    },
+    "GrpcRouteMetadata": {
+      "base": "<p>An object that represents the match metadata for the route.</p>",
+      "refs": {
+        "GrpcRouteMetadata$invert": "<p>Specify <code>True</code> to match anything except the match criteria. The default value is <code>False</code>.</p>",
+        "GrpcRouteMetadata$match": "<p>An object that represents the data to match from the request.</p>",
+        "GrpcRouteMetadata$name": "<p>The name of the route.</p>"
+      }
+    },
+    "GrpcRouteMetadataList": {
+      "base": null,
+      "refs": {
+        "GrpcRouteMetadataList$member": null
+      }
+    },
+    "GrpcRouteMetadataMatchMethod": {
+      "base": "<p>An object that represents the match method. Specify one of the match values.</p>",
+      "refs": {
+        "GrpcRouteMetadataMatchMethod$exact": "<p>The value sent by the client must match the specified value exactly.</p>",
+        "GrpcRouteMetadataMatchMethod$prefix": "<p>The value sent by the client must begin with the specified characters.</p>",
+        "GrpcRouteMetadataMatchMethod$range": "<p>An object that represents the range of values to match on.</p>",
+        "GrpcRouteMetadataMatchMethod$regex": "<p>The value sent by the client must include the specified characters.</p>",
+        "GrpcRouteMetadataMatchMethod$suffix": "<p>The value sent by the client must end with the specified characters.</p>"
+      }
+    },
+    "GrpcTimeout": {
+      "base": null,
+      "refs": { }
+    },
+    "HeaderMatch": {
+      "base": null,
+      "refs": { }
+    },
+    "HeaderMatchMethod": {
+      "base": "<p>An object that represents the method and value to match with the header value sent in a\n         request. Specify one match method.</p>",
+      "refs": {
+        "HeaderMatchMethod$exact": "<p>The value sent by the client must match the specified value exactly.</p>",
+        "HeaderMatchMethod$prefix": "<p>The value sent by the client must begin with the specified characters.</p>",
+        "HeaderMatchMethod$range": "<p>An object that represents the range of values to match on.</p>",
+        "HeaderMatchMethod$regex": "<p>The value sent by the client must include the specified characters.</p>",
+        "HeaderMatchMethod$suffix": "<p>The value sent by the client must end with the specified characters.</p>"
+      }
+    },
+    "HeaderName": {
+      "base": null,
+      "refs": { }
+    },
+    "HealthCheckIntervalMillis": {
+      "base": null,
+      "refs": { }
+    },
+    "HealthCheckPolicy": {
+      "base": "<p>An object that represents the health check policy for a virtual node's listener.</p>",
+      "refs": {
+        "HealthCheckPolicy$healthyThreshold": "<p>The number of consecutive successful health checks that must occur before declaring\n         listener healthy.</p>",
+        "HealthCheckPolicy$intervalMillis": "<p>The time period in milliseconds between each health check execution.</p>",
+        "HealthCheckPolicy$path": "<p>The destination path for the health check request. This value is only used if the\n         specified protocol is HTTP or HTTP/2. For any other protocol, this value is ignored.</p>",
+        "HealthCheckPolicy$port": "<p>The destination port for the health check request. This port must match the port defined\n         in the <a>PortMapping</a> for the listener.</p>",
+        "HealthCheckPolicy$protocol": "<p>The protocol for the health check request. If you specify <code>grpc</code>, then your\n         service must conform to the <a href=\"https://github.com/grpc/grpc/blob/master/doc/health-checking.md\">GRPC Health\n            Checking Protocol</a>.</p>",
+        "HealthCheckPolicy$timeoutMillis": "<p>The amount of time to wait when receiving a response from the health check, in\n         milliseconds.</p>",
+        "HealthCheckPolicy$unhealthyThreshold": "<p>The number of consecutive failed health checks that must occur before declaring a\n         virtual node unhealthy. </p>"
+      }
+    },
+    "HealthCheckThreshold": {
+      "base": null,
+      "refs": { }
+    },
+    "HealthCheckTimeoutMillis": {
+      "base": null,
+      "refs": { }
+    },
+    "Hostname": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpGatewayRoute": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpGatewayRouteAction": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpGatewayRouteMatch": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpMethod": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpRetryPolicy": {
+      "base": "<p>An object that represents a retry policy. Specify at least one value for at least one of the types of <code>RetryEvents</code>, a value for <code>maxRetries</code>, and a value for <code>perRetryTimeout</code>.</p>",
+      "refs": {
+        "HttpRetryPolicy$httpRetryEvents": "<p>Specify at least one of the following values.</p> \n         <ul>\n            <li>\n               <p>\n                  <b>server-error</b> – HTTP status codes 500, 501,\n                  502, 503, 504, 505, 506, 507, 508, 510, and 511</p>\n            </li>\n            <li>\n               <p>\n                  <b>gateway-error</b> – HTTP status codes 502,\n                  503, and 504</p>\n            </li>\n            <li>\n               <p>\n                  <b>client-error</b> – HTTP status code 409</p>\n            </li>\n            <li>\n               <p>\n                  <b>stream-error</b> – Retry on refused\n                  stream</p>\n            </li>\n         </ul>",
+        "HttpRetryPolicy$maxRetries": "<p>The maximum number of retry attempts.</p>",
+        "HttpRetryPolicy$perRetryTimeout": "<p>An object that represents a duration of time.</p>",
+        "HttpRetryPolicy$tcpRetryEvents": "<p>Specify a valid value.</p>"
+      }
+    },
+    "HttpRetryPolicyEvent": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpRetryPolicyEvents": {
+      "base": null,
+      "refs": {
+        "HttpRetryPolicyEvents$member": null
+      }
+    },
+    "HttpRoute": {
+      "base": "<p>An object that represents an HTTP or HTTP/2 route type.</p>",
+      "refs": {
+        "HttpRoute$action": "<p>An object that represents the action to take if a match is determined.</p>",
+        "HttpRoute$match": "<p>An object that represents the criteria for determining a request match.</p>",
+        "HttpRoute$retryPolicy": "<p>An object that represents a retry policy.</p>"
+      }
+    },
+    "HttpRouteAction": {
+      "base": "<p>An object that represents the action to take if a match is determined.</p>",
+      "refs": {
+        "HttpRouteAction$weightedTargets": "<p>An object that represents the targets that traffic is routed to when a request matches the route.</p>"
+      }
+    },
+    "HttpRouteHeader": {
+      "base": "<p>An object that represents the HTTP header in the request.</p>",
+      "refs": {
+        "HttpRouteHeader$invert": "<p>Specify <code>True</code> to match anything except the match criteria. The default value is <code>False</code>.</p>",
+        "HttpRouteHeader$match": "<p>The <code>HeaderMatchMethod</code> object.</p>",
+        "HttpRouteHeader$name": "<p>A name for the HTTP header in the client request that will be matched on.</p>"
+      }
+    },
+    "HttpRouteHeaders": {
+      "base": null,
+      "refs": {
+        "HttpRouteHeaders$member": null
+      }
+    },
+    "HttpRouteMatch": {
+      "base": "<p>An object that represents the requirements for a route to match HTTP requests for a\n         virtual router.</p>",
+      "refs": {
+        "HttpRouteMatch$headers": "<p>An object that represents the client request headers to match on.</p>",
+        "HttpRouteMatch$method": "<p>The client request method to match on. Specify only one.</p>",
+        "HttpRouteMatch$prefix": "<p>Specifies the path to match requests with. This parameter must always start with\n            <code>/</code>, which by itself matches all requests to the virtual service name. You\n         can also match for path-based routing of requests. For example, if your virtual service\n         name is <code>my-service.local</code> and you want the route to match requests to\n            <code>my-service.local/metrics</code>, your prefix should be\n         <code>/metrics</code>.</p>",
+        "HttpRouteMatch$scheme": "<p>The client request scheme to match on. Specify only one.</p>"
+      }
+    },
+    "HttpScheme": {
+      "base": null,
+      "refs": { }
+    },
+    "HttpTimeout": {
+      "base": null,
+      "refs": { }
+    },
+    "InternalServerErrorException": {
+      "base": "<p>The request processing has failed because of an unknown error, exception, or\n         failure.</p>",
+      "refs": { }
+    },
+    "LimitExceededException": {
+      "base": "<p>You have exceeded a service limit for your account. For more information, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/service-quotas.html\">Service\n            Limits</a> in the <i>AWS App Mesh User Guide</i>.</p>",
+      "refs": { }
+    },
+    "ListGatewayRoutesInput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListGatewayRoutesLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListGatewayRoutesOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListMeshesInput": {
+      "base": "",
+      "refs": {
+        "ListMeshesInput$limit": "<p>The maximum number of results returned by <code>ListMeshes</code> in paginated output.\n         When you use this parameter, <code>ListMeshes</code> returns only <code>limit</code>\n         results in a single page along with a <code>nextToken</code> response element. You can see\n         the remaining results of the initial request by sending another <code>ListMeshes</code>\n         request with the returned <code>nextToken</code> value. This value can be between\n         1 and 100. If you don't use this parameter,\n            <code>ListMeshes</code> returns up to 100 results and a\n            <code>nextToken</code> value if applicable.</p>",
+        "ListMeshesInput$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated\n            <code>ListMeshes</code> request where <code>limit</code> was used and the results\n         exceeded the value of that parameter. Pagination continues from the end of the previous\n         results that returned the <code>nextToken</code> value.</p> \n         <note>\n            <p>This token should be treated as an opaque identifier that is used only to\n                retrieve the next items in a list and not for other programmatic purposes.</p>\n        </note>"
+      }
+    },
+    "ListMeshesLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListMeshesOutput": {
+      "base": "",
+      "refs": {
+        "ListMeshesOutput$meshes": "<p>The list of existing service meshes.</p>",
+        "ListMeshesOutput$nextToken": "<p>The <code>nextToken</code> value to include in a future <code>ListMeshes</code> request.\n         When the results of a <code>ListMeshes</code> request exceed <code>limit</code>, you can\n         use this value to retrieve the next page of results. This value is <code>null</code> when\n         there are no more results to return.</p>"
+      }
+    },
+    "ListRoutesInput": {
+      "base": "",
+      "refs": {
+        "ListRoutesInput$limit": "<p>The maximum number of results returned by <code>ListRoutes</code> in paginated output.\n         When you use this parameter, <code>ListRoutes</code> returns only <code>limit</code>\n         results in a single page along with a <code>nextToken</code> response element. You can see\n         the remaining results of the initial request by sending another <code>ListRoutes</code>\n         request with the returned <code>nextToken</code> value. This value can be between\n         1 and 100. If you don't use this parameter,\n            <code>ListRoutes</code> returns up to 100 results and a\n            <code>nextToken</code> value if applicable.</p>",
+        "ListRoutesInput$meshName": "<p>The name of the service mesh to list routes in.</p>",
+        "ListRoutesInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "ListRoutesInput$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated\n            <code>ListRoutes</code> request where <code>limit</code> was used and the results\n         exceeded the value of that parameter. Pagination continues from the end of the previous\n         results that returned the <code>nextToken</code> value.</p>",
+        "ListRoutesInput$virtualRouterName": "<p>The name of the virtual router to list routes in.</p>"
+      }
+    },
+    "ListRoutesLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListRoutesOutput": {
+      "base": "",
+      "refs": {
+        "ListRoutesOutput$nextToken": "<p>The <code>nextToken</code> value to include in a future <code>ListRoutes</code> request.\n         When the results of a <code>ListRoutes</code> request exceed <code>limit</code>, you can\n         use this value to retrieve the next page of results. This value is <code>null</code> when\n         there are no more results to return.</p>",
+        "ListRoutesOutput$routes": "<p>The list of existing routes for the specified service mesh and virtual router.</p>"
+      }
+    },
+    "ListVirtualGatewaysInput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualGatewaysLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualGatewaysOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualNodesInput": {
+      "base": "",
+      "refs": {
+        "ListVirtualNodesInput$limit": "<p>The maximum number of results returned by <code>ListVirtualNodes</code> in paginated\n         output. When you use this parameter, <code>ListVirtualNodes</code> returns only\n            <code>limit</code> results in a single page along with a <code>nextToken</code> response\n         element. You can see the remaining results of the initial request by sending another\n            <code>ListVirtualNodes</code> request with the returned <code>nextToken</code> value.\n         This value can be between 1 and 100. If you don't use this\n         parameter, <code>ListVirtualNodes</code> returns up to 100 results and a\n            <code>nextToken</code> value if applicable.</p>",
+        "ListVirtualNodesInput$meshName": "<p>The name of the service mesh to list virtual nodes in.</p>",
+        "ListVirtualNodesInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "ListVirtualNodesInput$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated\n            <code>ListVirtualNodes</code> request where <code>limit</code> was used and the results\n         exceeded the value of that parameter. Pagination continues from the end of the previous\n         results that returned the <code>nextToken</code> value.</p>"
+      }
+    },
+    "ListVirtualNodesLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualNodesOutput": {
+      "base": "",
+      "refs": {
+        "ListVirtualNodesOutput$nextToken": "<p>The <code>nextToken</code> value to include in a future <code>ListVirtualNodes</code>\n         request. When the results of a <code>ListVirtualNodes</code> request exceed\n            <code>limit</code>, you can use this value to retrieve the next page of results. This\n         value is <code>null</code> when there are no more results to return.</p>",
+        "ListVirtualNodesOutput$virtualNodes": "<p>The list of existing virtual nodes for the specified service mesh.</p>"
+      }
+    },
+    "ListVirtualRoutersInput": {
+      "base": "",
+      "refs": {
+        "ListVirtualRoutersInput$limit": "<p>The maximum number of results returned by <code>ListVirtualRouters</code> in paginated\n         output. When you use this parameter, <code>ListVirtualRouters</code> returns only\n            <code>limit</code> results in a single page along with a <code>nextToken</code> response\n         element. You can see the remaining results of the initial request by sending another\n            <code>ListVirtualRouters</code> request with the returned <code>nextToken</code> value.\n         This value can be between 1 and 100. If you don't use this\n         parameter, <code>ListVirtualRouters</code> returns up to 100 results and\n         a <code>nextToken</code> value if applicable.</p>",
+        "ListVirtualRoutersInput$meshName": "<p>The name of the service mesh to list virtual routers in.</p>",
+        "ListVirtualRoutersInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "ListVirtualRoutersInput$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated\n            <code>ListVirtualRouters</code> request where <code>limit</code> was used and the\n         results exceeded the value of that parameter. Pagination continues from the end of the\n         previous results that returned the <code>nextToken</code> value.</p>"
+      }
+    },
+    "ListVirtualRoutersLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualRoutersOutput": {
+      "base": "",
+      "refs": {
+        "ListVirtualRoutersOutput$nextToken": "<p>The <code>nextToken</code> value to include in a future <code>ListVirtualRouters</code>\n         request. When the results of a <code>ListVirtualRouters</code> request exceed\n            <code>limit</code>, you can use this value to retrieve the next page of results. This\n         value is <code>null</code> when there are no more results to return.</p>",
+        "ListVirtualRoutersOutput$virtualRouters": "<p>The list of existing virtual routers for the specified service mesh.</p>"
+      }
+    },
+    "ListVirtualServicesInput": {
+      "base": "",
+      "refs": {
+        "ListVirtualServicesInput$limit": "<p>The maximum number of results returned by <code>ListVirtualServices</code> in paginated\n         output. When you use this parameter, <code>ListVirtualServices</code> returns only\n            <code>limit</code> results in a single page along with a <code>nextToken</code> response\n         element. You can see the remaining results of the initial request by sending another\n            <code>ListVirtualServices</code> request with the returned <code>nextToken</code> value.\n         This value can be between 1 and 100. If you don't use this\n         parameter, <code>ListVirtualServices</code> returns up to 100 results and\n         a <code>nextToken</code> value if applicable.</p>",
+        "ListVirtualServicesInput$meshName": "<p>The name of the service mesh to list virtual services in.</p>",
+        "ListVirtualServicesInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "ListVirtualServicesInput$nextToken": "<p>The <code>nextToken</code> value returned from a previous paginated\n            <code>ListVirtualServices</code> request where <code>limit</code> was used and the\n         results exceeded the value of that parameter. Pagination continues from the end of the\n         previous results that returned the <code>nextToken</code> value.</p>"
+      }
+    },
+    "ListVirtualServicesLimit": {
+      "base": null,
+      "refs": { }
+    },
+    "ListVirtualServicesOutput": {
+      "base": "",
+      "refs": {
+        "ListVirtualServicesOutput$nextToken": "<p>The <code>nextToken</code> value to include in a future <code>ListVirtualServices</code>\n         request. When the results of a <code>ListVirtualServices</code> request exceed\n            <code>limit</code>, you can use this value to retrieve the next page of results. This\n         value is <code>null</code> when there are no more results to return.</p>",
+        "ListVirtualServicesOutput$virtualServices": "<p>The list of existing virtual services for the specified service mesh.</p>"
+      }
+    },
+    "Listener": {
+      "base": "<p>An object that represents a listener for a virtual node.</p>",
+      "refs": {
+        "Listener$healthCheck": "<p>The health check information for the listener.</p>",
+        "Listener$portMapping": "<p>The port mapping information for the listener.</p>",
+        "Listener$tls": "<p>A reference to an object that represents the Transport Layer Security (TLS) properties for a listener.</p>"
+      }
+    },
+    "ListenerTimeout": {
+      "base": null,
+      "refs": { }
+    },
+    "ListenerTls": {
+      "base": "<p>An object that represents the Transport Layer Security (TLS) properties for a listener.</p>",
+      "refs": {
+        "ListenerTls$certificate": "<p>A reference to an object that represents a listener's TLS certificate.</p>",
+        "ListenerTls$mode": "<p>Specify one of the following modes.</p>\n         <ul>\n            <li>\n               <p>\n                  <b/>STRICT – Listener only accepts connections with TLS\n               enabled. </p>\n            </li>\n            <li>\n               <p>\n                  <b/>PERMISSIVE – Listener accepts connections with or\n               without TLS enabled.</p>\n            </li>\n            <li>\n               <p>\n                  <b/>DISABLED – Listener only accepts connections without\n               TLS. </p>\n            </li>\n         </ul>"
+      }
+    },
+    "ListenerTlsAcmCertificate": {
+      "base": "<p>An object that represents an AWS Certicate Manager (ACM) certificate.</p>",
+      "refs": {
+        "ListenerTlsAcmCertificate$certificateArn": "<p>The Amazon Resource Name (ARN) for the certificate. The certificate must meet specific requirements and you must have proxy authorization enabled. For more information, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/tls.html#virtual-node-tls-prerequisites\">Transport Layer Security (TLS)</a>.</p>"
+      }
+    },
+    "ListenerTlsCertificate": {
+      "base": "<p>An object that represents a listener's Transport Layer Security (TLS) certificate.</p>",
+      "refs": {
+        "ListenerTlsCertificate$acm": "<p>A reference to an object that represents an AWS Certicate Manager (ACM) certificate.</p>",
+        "ListenerTlsCertificate$file": "<p>A reference to an object that represents a local file certificate.</p>"
+      }
+    },
+    "ListenerTlsFileCertificate": {
+      "base": "<p>An object that represents a local file certificate.\n         The certificate must meet specific requirements and you must have proxy authorization enabled. For more information, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/tls.html#virtual-node-tls-prerequisites\">Transport Layer Security (TLS)</a>.</p>",
+      "refs": {
+        "ListenerTlsFileCertificate$certificateChain": "<p>The certificate chain for the certificate.</p>",
+        "ListenerTlsFileCertificate$privateKey": "<p>The private key for a certificate stored on the file system of the virtual node that the\n         proxy is running on.</p>"
+      }
+    },
+    "ListenerTlsMode": {
+      "base": null,
+      "refs": { }
+    },
+    "Listeners": {
+      "base": null,
+      "refs": {
+        "Listeners$member": null
+      }
+    },
+    "Logging": {
+      "base": "<p>An object that represents the logging information for a virtual node.</p>",
+      "refs": {
+        "Logging$accessLog": "<p>The access log configuration for a virtual node.</p>"
+      }
+    },
+    "Long": {
+      "base": null,
+      "refs": { }
+    },
+    "MatchRange": {
+      "base": "<p>An object that represents the range of values to match on. The first character of the range is included in the range, though the last character is not. For example, if the range specified were 1-100, only values 1-99 would be matched.</p>",
+      "refs": {
+        "MatchRange$end": "<p>The end of the range.</p>",
+        "MatchRange$start": "<p>The start of the range.</p>"
+      }
+    },
+    "MaxRetries": {
+      "base": null,
+      "refs": { }
+    },
+    "MeshData": {
+      "base": "<p>An object that represents a service mesh returned by a describe operation.</p>",
+      "refs": {
+        "MeshData$meshName": "<p>The name of the service mesh.</p>",
+        "MeshData$metadata": "<p>The associated metadata for the service mesh.</p>",
+        "MeshData$spec": "<p>The associated specification for the service mesh.</p>",
+        "MeshData$status": "<p>The status of the service mesh.</p>"
+      }
+    },
+    "MeshList": {
+      "base": null,
+      "refs": {
+        "MeshList$member": null
+      }
+    },
+    "MeshRef": {
+      "base": "<p>An object that represents a service mesh returned by a list operation.</p>",
+      "refs": {
+        "MeshRef$arn": "<p>The full Amazon Resource Name (ARN) of the service mesh.</p>",
+        "MeshRef$createdAt": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>",
+        "MeshRef$lastUpdatedAt": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>",
+        "MeshRef$meshName": "<p>The name of the service mesh.</p>",
+        "MeshRef$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "MeshRef$resourceOwner": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "MeshRef$version": "<p>The version of the resource. Resources are created at version 1, and this version is incremented each time that they're updated.</p>"
+      }
+    },
+    "MeshSpec": {
+      "base": "<p>An object that represents the specification of a service mesh.</p>",
+      "refs": {
+        "MeshSpec$egressFilter": "<p>The egress filter rules for the service mesh.</p>"
+      }
+    },
+    "MeshStatus": {
+      "base": "<p>An object that represents the status of a service mesh.</p>",
+      "refs": {
+        "MeshStatus$status": "<p>The current mesh status.</p>"
+      }
+    },
+    "MeshStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "MethodName": {
+      "base": null,
+      "refs": { }
+    },
+    "NotFoundException": {
+      "base": "<p>The specified resource doesn't exist. Check your request syntax and try again.</p>",
+      "refs": { }
+    },
+    "PercentInt": {
+      "base": null,
+      "refs": { }
+    },
+    "PortMapping": {
+      "base": "<p>An object that represents a port mapping.</p>",
+      "refs": {
+        "PortMapping$port": "<p>The port used for the port mapping.</p>",
+        "PortMapping$protocol": "<p>The protocol used for the port mapping. Specify one protocol.</p>"
+      }
+    },
+    "PortNumber": {
+      "base": null,
+      "refs": { }
+    },
+    "PortProtocol": {
+      "base": null,
+      "refs": { }
+    },
+    "PortSet": {
+      "base": null,
+      "refs": {
+        "PortSet$member": null
+      }
+    },
+    "ResourceInUseException": {
+      "base": "<p>You can't delete the specified resource because it's in use or required by another\n         resource.</p>",
+      "refs": { }
+    },
+    "ResourceMetadata": {
+      "base": "<p>An object that represents metadata for a resource.</p>",
+      "refs": {
+        "ResourceMetadata$arn": "<p>The full Amazon Resource Name (ARN) for the resource.</p>",
+        "ResourceMetadata$createdAt": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>",
+        "ResourceMetadata$lastUpdatedAt": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>",
+        "ResourceMetadata$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "ResourceMetadata$resourceOwner": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "ResourceMetadata$uid": "<p>The unique identifier for the resource.</p>",
+        "ResourceMetadata$version": "<p>The version of the resource. Resources are created at version 1, and this version is\n         incremented each time that they're updated.</p>"
+      }
+    },
+    "ResourceName": {
+      "base": null,
+      "refs": { }
+    },
+    "RouteData": {
+      "base": "<p>An object that represents a route returned by a describe operation.</p>",
+      "refs": {
+        "RouteData$meshName": "<p>The name of the service mesh that the route resides in.</p>",
+        "RouteData$metadata": "<p>The associated metadata for the route.</p>",
+        "RouteData$routeName": "<p>The name of the route.</p>",
+        "RouteData$spec": "<p>The specifications of the route.</p>",
+        "RouteData$status": "<p>The status of the route.</p>",
+        "RouteData$virtualRouterName": "<p>The virtual router that the route is associated with.</p>"
+      }
+    },
+    "RouteList": {
+      "base": null,
+      "refs": {
+        "RouteList$member": null
+      }
+    },
+    "RoutePriority": {
+      "base": null,
+      "refs": { }
+    },
+    "RouteRef": {
+      "base": "<p>An object that represents a route returned by a list operation.</p>",
+      "refs": {
+        "RouteRef$arn": "<p>The full Amazon Resource Name (ARN) for the route.</p>",
+        "RouteRef$createdAt": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>",
+        "RouteRef$lastUpdatedAt": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>",
+        "RouteRef$meshName": "<p>The name of the service mesh that the route resides in.</p>",
+        "RouteRef$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "RouteRef$resourceOwner": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "RouteRef$routeName": "<p>The name of the route.</p>",
+        "RouteRef$version": "<p>The version of the resource. Resources are created at version 1, and this version is incremented each time that they're updated.</p>",
+        "RouteRef$virtualRouterName": "<p>The virtual router that the route is associated with.</p>"
+      }
+    },
+    "RouteSpec": {
+      "base": "<p>An object that represents a route specification. Specify one route type.</p>",
+      "refs": {
+        "RouteSpec$grpcRoute": "<p>An object that represents the specification of a gRPC route.</p>",
+        "RouteSpec$http2Route": "<p>An object that represents the specification of an HTTP/2 route.</p>",
+        "RouteSpec$httpRoute": "<p>An object that represents the specification of an HTTP route.</p>",
+        "RouteSpec$priority": "<p>The priority for the route. Routes are matched based on the specified value, where 0 is\n         the highest priority.</p>",
+        "RouteSpec$tcpRoute": "<p>An object that represents the specification of a TCP route.</p>"
+      }
+    },
+    "RouteStatus": {
+      "base": "<p>An object that represents the current status of a route.</p>",
+      "refs": {
+        "RouteStatus$status": "<p>The current status for the route.</p>"
+      }
+    },
+    "RouteStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "ServiceDiscovery": {
+      "base": "<p>An object that represents the service discovery information for a virtual node.</p>",
+      "refs": {
+        "ServiceDiscovery$awsCloudMap": "<p>Specifies any AWS Cloud Map information for the virtual node.</p>",
+        "ServiceDiscovery$dns": "<p>Specifies the DNS information for the virtual node.</p>"
+      }
+    },
+    "ServiceName": {
+      "base": null,
+      "refs": { }
+    },
+    "ServiceUnavailableException": {
+      "base": "<p>The request has failed due to a temporary failure of the service.</p>",
+      "refs": { }
+    },
+    "String": {
+      "base": null,
+      "refs": { }
+    },
+    "TagKey": {
+      "base": null,
+      "refs": { }
+    },
+    "TagList": {
+      "base": null,
+      "refs": {
+        "TagList$member": null
+      }
+    },
+    "TagRef": {
+      "base": "<p>Optional metadata that you apply to a resource to assist with categorization and\n         organization. Each tag consists of a key and an optional value, both of which you define.\n         Tag keys can have a maximum character length of 128 characters, and tag values can have\n            a maximum length of 256 characters.</p>",
+      "refs": {
+        "TagRef$key": "<p>One part of a key-value pair that make up a tag. A <code>key</code> is a general label\n         that acts like a category for more specific tag values.</p>",
+        "TagRef$value": "<p>The optional part of a key-value pair that make up a tag. A <code>value</code> acts as a\n         descriptor within a tag category (key).</p>"
+      }
+    },
+    "TagValue": {
+      "base": null,
+      "refs": { }
+    },
+    "TcpRetryPolicyEvent": {
+      "base": null,
+      "refs": { }
+    },
+    "TcpRetryPolicyEvents": {
+      "base": null,
+      "refs": {
+        "TcpRetryPolicyEvents$member": null
+      }
+    },
+    "TcpRoute": {
+      "base": "<p>An object that represents a TCP route type.</p>",
+      "refs": {
+        "TcpRoute$action": "<p>The action to take if a match is determined.</p>"
+      }
+    },
+    "TcpRouteAction": {
+      "base": "<p>An object that represents the action to take if a match is determined.</p>",
+      "refs": {
+        "TcpRouteAction$weightedTargets": "<p>An object that represents the targets that traffic is routed to when a request matches the route.</p>"
+      }
+    },
+    "TcpTimeout": {
+      "base": null,
+      "refs": { }
+    },
+    "Timestamp": {
+      "base": null,
+      "refs": { }
+    },
+    "TlsValidationContext": {
+      "base": "<p>An object that represents a Transport Layer Security (TLS) validation context.</p>",
+      "refs": {
+        "TlsValidationContext$trust": "<p>A reference to an object that represents a TLS validation context trust.</p>"
+      }
+    },
+    "TlsValidationContextAcmTrust": {
+      "base": "<p>An object that represents a TLS validation context trust for an AWS Certicate Manager (ACM)\n         certificate.</p>",
+      "refs": {
+        "TlsValidationContextAcmTrust$certificateAuthorityArns": "<p>One or more ACM Amazon Resource Name (ARN)s.</p>"
+      }
+    },
+    "TlsValidationContextFileTrust": {
+      "base": "<p>An object that represents a Transport Layer Security (TLS) validation context trust for a local file.</p>",
+      "refs": {
+        "TlsValidationContextFileTrust$certificateChain": "<p>The certificate trust chain for a certificate stored on the file system of the virtual\n         node that the proxy is running on.</p>"
+      }
+    },
+    "TlsValidationContextTrust": {
+      "base": "<p>An object that represents a Transport Layer Security (TLS) validation context trust.</p>",
+      "refs": {
+        "TlsValidationContextTrust$acm": "<p>A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM)\n         certificate.</p>",
+        "TlsValidationContextTrust$file": "<p>An object that represents a TLS validation context trust for a local file.</p>"
+      }
+    },
+    "TooManyRequestsException": {
+      "base": "<p>The maximum request rate permitted by the App Mesh APIs has been exceeded for your\n         account. For best results, use an increasing or variable sleep interval between\n         requests.</p>",
+      "refs": { }
+    },
+    "UpdateGatewayRouteInput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateGatewayRouteOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateMeshInput": {
+      "base": "",
+      "refs": {
+        "UpdateMeshInput$clientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+        "UpdateMeshInput$meshName": "<p>The name of the service mesh to update.</p>",
+        "UpdateMeshInput$spec": "<p>The service mesh specification to apply.</p>"
+      }
+    },
+    "UpdateMeshOutput": {
+      "base": "",
+      "refs": { }
+    },
+    "UpdateRouteInput": {
+      "base": "",
+      "refs": {
+        "UpdateRouteInput$clientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+        "UpdateRouteInput$meshName": "<p>The name of the service mesh that the route resides in.</p>",
+        "UpdateRouteInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "UpdateRouteInput$routeName": "<p>The name of the route to update.</p>",
+        "UpdateRouteInput$spec": "<p>The new route specification to apply. This overwrites the existing data.</p>",
+        "UpdateRouteInput$virtualRouterName": "<p>The name of the virtual router that the route is associated with.</p>"
+      }
+    },
+    "UpdateRouteOutput": {
+      "base": "",
+      "refs": {
+        "UpdateRouteOutput$route": "<p>A full description of the route that was updated.</p>"
+      }
+    },
+    "UpdateVirtualGatewayInput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateVirtualGatewayOutput": {
+      "base": null,
+      "refs": { }
+    },
+    "UpdateVirtualNodeInput": {
+      "base": "",
+      "refs": {
+        "UpdateVirtualNodeInput$clientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+        "UpdateVirtualNodeInput$meshName": "<p>The name of the service mesh that the virtual node resides in.</p>",
+        "UpdateVirtualNodeInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "UpdateVirtualNodeInput$spec": "<p>The new virtual node specification to apply. This overwrites the existing data.</p>",
+        "UpdateVirtualNodeInput$virtualNodeName": "<p>The name of the virtual node to update.</p>"
+      }
+    },
+    "UpdateVirtualNodeOutput": {
+      "base": "",
+      "refs": {
+        "UpdateVirtualNodeOutput$virtualNode": "<p>A full description of the virtual node that was updated.</p>"
+      }
+    },
+    "UpdateVirtualRouterInput": {
+      "base": "",
+      "refs": {
+        "UpdateVirtualRouterInput$clientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+        "UpdateVirtualRouterInput$meshName": "<p>The name of the service mesh that the virtual router resides in.</p>",
+        "UpdateVirtualRouterInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "UpdateVirtualRouterInput$spec": "<p>The new virtual router specification to apply. This overwrites the existing data.</p>",
+        "UpdateVirtualRouterInput$virtualRouterName": "<p>The name of the virtual router to update.</p>"
+      }
+    },
+    "UpdateVirtualRouterOutput": {
+      "base": "",
+      "refs": {
+        "UpdateVirtualRouterOutput$virtualRouter": "<p>A full description of the virtual router that was updated.</p>"
+      }
+    },
+    "UpdateVirtualServiceInput": {
+      "base": "",
+      "refs": {
+        "UpdateVirtualServiceInput$clientToken": "<p>Unique, case-sensitive identifier that you provide to ensure the idempotency of the\nrequest. Up to 36 letters, numbers, hyphens, and underscores are allowed.</p>",
+        "UpdateVirtualServiceInput$meshName": "<p>The name of the service mesh that the virtual service resides in.</p>",
+        "UpdateVirtualServiceInput$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "UpdateVirtualServiceInput$spec": "<p>The new virtual service specification to apply. This overwrites the existing\n         data.</p>",
+        "UpdateVirtualServiceInput$virtualServiceName": "<p>The name of the virtual service to update.</p>"
+      }
+    },
+    "UpdateVirtualServiceOutput": {
+      "base": "",
+      "refs": {
+        "UpdateVirtualServiceOutput$virtualService": "<p>A full description of the virtual service that was updated.</p>"
+      }
+    },
+    "VirtualGatewayAccessLog": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayBackendDefaults": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayCertificateAuthorityArns": {
+      "base": null,
+      "refs": {
+        "VirtualGatewayCertificateAuthorityArns$member": null
+      }
+    },
+    "VirtualGatewayClientPolicy": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayClientPolicyTls": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayData": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayFileAccessLog": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayHealthCheckIntervalMillis": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayHealthCheckPolicy": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayHealthCheckThreshold": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayHealthCheckTimeoutMillis": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayList": {
+      "base": null,
+      "refs": {
+        "VirtualGatewayList$member": null
+      }
+    },
+    "VirtualGatewayListener": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTls": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTlsAcmCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTlsCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTlsFileCertificate": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListenerTlsMode": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayListeners": {
+      "base": null,
+      "refs": {
+        "VirtualGatewayListeners$member": null
+      }
+    },
+    "VirtualGatewayLogging": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayPortMapping": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayPortProtocol": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayRef": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewaySpec": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayStatus": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayTlsValidationContext": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayTlsValidationContextAcmTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayTlsValidationContextFileTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualGatewayTlsValidationContextTrust": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualNodeData": {
+      "base": "<p>An object that represents a virtual node returned by a describe operation.</p>",
+      "refs": {
+        "VirtualNodeData$meshName": "<p>The name of the service mesh that the virtual node resides in.</p>",
+        "VirtualNodeData$metadata": "<p>The associated metadata for the virtual node.</p>",
+        "VirtualNodeData$spec": "<p>The specifications of the virtual node.</p>",
+        "VirtualNodeData$status": "<p>The current status for the virtual node.</p>",
+        "VirtualNodeData$virtualNodeName": "<p>The name of the virtual node.</p>"
+      }
+    },
+    "VirtualNodeList": {
+      "base": null,
+      "refs": {
+        "VirtualNodeList$member": null
+      }
+    },
+    "VirtualNodeRef": {
+      "base": "<p>An object that represents a virtual node returned by a list operation.</p>",
+      "refs": {
+        "VirtualNodeRef$arn": "<p>The full Amazon Resource Name (ARN) for the virtual node.</p>",
+        "VirtualNodeRef$createdAt": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>",
+        "VirtualNodeRef$lastUpdatedAt": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>",
+        "VirtualNodeRef$meshName": "<p>The name of the service mesh that the virtual node resides in.</p>",
+        "VirtualNodeRef$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "VirtualNodeRef$resourceOwner": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "VirtualNodeRef$version": "<p>The version of the resource. Resources are created at version 1, and this version is incremented each time that they're updated.</p>",
+        "VirtualNodeRef$virtualNodeName": "<p>The name of the virtual node.</p>"
+      }
+    },
+    "VirtualNodeServiceProvider": {
+      "base": "<p>An object that represents a virtual node service provider.</p>",
+      "refs": {
+        "VirtualNodeServiceProvider$virtualNodeName": "<p>The name of the virtual node that is acting as a service provider.</p>"
+      }
+    },
+    "VirtualNodeSpec": {
+      "base": "<p>An object that represents the specification of a virtual node.</p>",
+      "refs": {
+        "VirtualNodeSpec$backendDefaults": "<p>A reference to an object that represents the defaults for backends.</p>",
+        "VirtualNodeSpec$backends": "<p>The backends that the virtual node is expected to send outbound traffic to.</p>",
+        "VirtualNodeSpec$listeners": "<p>The listener that the virtual node is expected to receive inbound traffic from. You can\n         specify one listener.</p>",
+        "VirtualNodeSpec$logging": "<p>The inbound and outbound access logging information for the virtual node.</p>",
+        "VirtualNodeSpec$serviceDiscovery": "<p>The service discovery information for the virtual node. If your virtual node does not\n         expect ingress traffic, you can omit this parameter. If you specify a\n         <code>listener</code>, then you must specify service discovery information.</p>"
+      }
+    },
+    "VirtualNodeStatus": {
+      "base": "<p>An object that represents the current status of the virtual node.</p>",
+      "refs": {
+        "VirtualNodeStatus$status": "<p>The current status of the virtual node.</p>"
+      }
+    },
+    "VirtualNodeStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualRouterData": {
+      "base": "<p>An object that represents a virtual router returned by a describe operation.</p>",
+      "refs": {
+        "VirtualRouterData$meshName": "<p>The name of the service mesh that the virtual router resides in.</p>",
+        "VirtualRouterData$metadata": "<p>The associated metadata for the virtual router.</p>",
+        "VirtualRouterData$spec": "<p>The specifications of the virtual router.</p>",
+        "VirtualRouterData$status": "<p>The current status of the virtual router.</p>",
+        "VirtualRouterData$virtualRouterName": "<p>The name of the virtual router.</p>"
+      }
+    },
+    "VirtualRouterList": {
+      "base": null,
+      "refs": {
+        "VirtualRouterList$member": null
+      }
+    },
+    "VirtualRouterListener": {
+      "base": "<p>An object that represents a virtual router listener.</p>",
+      "refs": { }
+    },
+    "VirtualRouterListeners": {
+      "base": null,
+      "refs": {
+        "VirtualRouterListeners$member": null
+      }
+    },
+    "VirtualRouterRef": {
+      "base": "<p>An object that represents a virtual router returned by a list operation.</p>",
+      "refs": {
+        "VirtualRouterRef$arn": "<p>The full Amazon Resource Name (ARN) for the virtual router.</p>",
+        "VirtualRouterRef$createdAt": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>",
+        "VirtualRouterRef$lastUpdatedAt": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>",
+        "VirtualRouterRef$meshName": "<p>The name of the service mesh that the virtual router resides in.</p>",
+        "VirtualRouterRef$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "VirtualRouterRef$resourceOwner": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "VirtualRouterRef$version": "<p>The version of the resource. Resources are created at version 1, and this version is incremented each time that they're updated.</p>",
+        "VirtualRouterRef$virtualRouterName": "<p>The name of the virtual router.</p>"
+      }
+    },
+    "VirtualRouterServiceProvider": {
+      "base": "<p>An object that represents a virtual node service provider.</p>",
+      "refs": {
+        "VirtualRouterServiceProvider$virtualRouterName": "<p>The name of the virtual router that is acting as a service provider.</p>"
+      }
+    },
+    "VirtualRouterSpec": {
+      "base": "<p>An object that represents the specification of a virtual router.</p>",
+      "refs": {
+        "VirtualRouterSpec$listeners": "<p>The listeners that the virtual router is expected to receive inbound traffic from. You\n         can specify one listener.</p>"
+      }
+    },
+    "VirtualRouterStatus": {
+      "base": "<p>An object that represents the status of a virtual router. </p>",
+      "refs": {
+        "VirtualRouterStatus$status": "<p>The current status of the virtual router.</p>"
+      }
+    },
+    "VirtualRouterStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "VirtualServiceBackend": {
+      "base": "<p>An object that represents a virtual service backend for a virtual node.</p>",
+      "refs": {
+        "VirtualServiceBackend$clientPolicy": "<p>A reference to an object that represents the client policy for a backend.</p>",
+        "VirtualServiceBackend$virtualServiceName": "<p>The name of the virtual service that is acting as a virtual node backend.</p>"
+      }
+    },
+    "VirtualServiceData": {
+      "base": "<p>An object that represents a virtual service returned by a describe operation.</p>",
+      "refs": {
+        "VirtualServiceData$meshName": "<p>The name of the service mesh that the virtual service resides in.</p>",
+        "VirtualServiceData$spec": "<p>The specifications of the virtual service.</p>",
+        "VirtualServiceData$status": "<p>The current status of the virtual service.</p>",
+        "VirtualServiceData$virtualServiceName": "<p>The name of the virtual service.</p>"
+      }
+    },
+    "VirtualServiceList": {
+      "base": null,
+      "refs": {
+        "VirtualServiceList$member": null
+      }
+    },
+    "VirtualServiceProvider": {
+      "base": "<p>An object that represents the provider for a virtual service.</p>",
+      "refs": {
+        "VirtualServiceProvider$virtualNode": "<p>The virtual node associated with a virtual service.</p>",
+        "VirtualServiceProvider$virtualRouter": "<p>The virtual router associated with a virtual service.</p>"
+      }
+    },
+    "VirtualServiceRef": {
+      "base": "<p>An object that represents a virtual service returned by a list operation.</p>",
+      "refs": {
+        "VirtualServiceRef$arn": "<p>The full Amazon Resource Name (ARN) for the virtual service.</p>",
+        "VirtualServiceRef$createdAt": "<p>The Unix epoch timestamp in seconds for when the resource was created.</p>",
+        "VirtualServiceRef$lastUpdatedAt": "<p>The Unix epoch timestamp in seconds for when the resource was last updated.</p>",
+        "VirtualServiceRef$meshName": "<p>The name of the service mesh that the virtual service resides in.</p>",
+        "VirtualServiceRef$meshOwner": "<p>The AWS IAM account ID of the service mesh owner. If the account ID is not your own, then it's\n               the ID of the account that shared the mesh with your account. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "VirtualServiceRef$resourceOwner": "<p>The AWS IAM account ID of the resource owner. If the account ID is not your own, then it's\n               the ID of the mesh owner or of another account that the mesh is shared with. For more information about mesh sharing, see <a href=\"https://docs.aws.amazon.com/app-mesh/latest/userguide/sharing.html\">Working with shared meshes</a>.</p>",
+        "VirtualServiceRef$version": "<p>The version of the resource. Resources are created at version 1, and this version is incremented each time that they're updated.</p>",
+        "VirtualServiceRef$virtualServiceName": "<p>The name of the virtual service.</p>"
+      }
+    },
+    "VirtualServiceSpec": {
+      "base": "<p>An object that represents the specification of a virtual service.</p>",
+      "refs": {
+        "VirtualServiceSpec$provider": "<p>The App Mesh object that is acting as the provider for a virtual service. You can specify\n         a single virtual node or virtual router.</p>"
+      }
+    },
+    "VirtualServiceStatus": {
+      "base": "<p>An object that represents the status of a virtual service.</p>",
+      "refs": {
+        "VirtualServiceStatus$status": "<p>The current status of the virtual service.</p>"
+      }
+    },
+    "VirtualServiceStatusCode": {
+      "base": null,
+      "refs": { }
+    },
+    "WeightedTarget": {
+      "base": "<p>An object that represents a target and its relative weight. Traffic is distributed\n         across targets according to their relative weight. For example, a weighted target with a\n         relative weight of 50 receives five times as much traffic as one with a relative weight of\n         10. The total weight for all targets combined must be less than or equal to 100.</p>",
+      "refs": {
+        "WeightedTarget$virtualNode": "<p>The virtual node to associate with the weighted target.</p>",
+        "WeightedTarget$weight": "<p>The relative weight of the weighted target.</p>"
+      }
+    },
+    "WeightedTargets": {
+      "base": null,
+      "refs": {
+        "WeightedTargets$member": null
+      }
+    }
+  }
+}

--- a/appmesh-preview/sdk/examples.json
+++ b/appmesh-preview/sdk/examples.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.0",
+  "examples": { }
+}

--- a/appmesh-preview/sdk/paginators.json
+++ b/appmesh-preview/sdk/paginators.json
@@ -1,0 +1,46 @@
+{
+  "pagination": {
+    "ListGatewayRoutes": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "gatewayRoutes"
+    },
+    "ListMeshes": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "meshes"
+    },
+    "ListRoutes": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "routes"
+    },
+    "ListVirtualGateways": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "virtualGateways"
+    },
+    "ListVirtualNodes": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "virtualNodes"
+    },
+    "ListVirtualRouters": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "virtualRouters"
+    },
+    "ListVirtualServices": {
+      "input_token": "nextToken",
+      "limit_key": "limit",
+      "output_token": "nextToken",
+      "result_key": "virtualServices"
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:* aws/aws-app-mesh-controller-for-k8s#75

*Description of changes:*

Adds all JSON files used for SDK generation. This will:

1. Allow a knowledgeable customer to generate their own SDK by replacing the models.
2. Allow us to add support for the preview channel in the kubernetes controller because of (1)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
