### PR TITLE
Fix an optional mTLS field to be required

### DIFF
--- a/appmesh-preview/service-model.json
+++ b/appmesh-preview/service-model.json
@@ -5307,6 +5307,9 @@
         },
         "VirtualGatewayListenerTlsSdsCertificate": {
             "type": "structure",
+            "required": [
+                "secretName"
+            ],
             "members": {
                 "secretName": {
                     "shape": "VirtualGatewaySdsSecretName"


### PR DESCRIPTION
*Description of changes:*

The SDS `secretName` field was erroneously marked optional for virtual gateways.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
