### PR TITLE
Change master to main in URL for sdk readme

### DIFF
--- a/appmesh-preview/sdk/README.md
+++ b/appmesh-preview/sdk/README.md
@@ -22,10 +22,10 @@ cd aws-sdk-go
 Download the JSON files, replacing the appropriate files in the SDK:
 
 ```bash
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/api.json > models/apis/appmesh/2019-01-25/api-2.json
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/docs.json > models/apis/appmesh/2019-01-25/docs-2.json
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/examples.json > models/apis/appmesh/2019-01-25/examples-1.json
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/paginators.json > models/apis/appmesh/2019-01-25/paginators-1.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/api.json > models/apis/appmesh/2019-01-25/api-2.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/docs.json > models/apis/appmesh/2019-01-25/docs-2.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/examples.json > models/apis/appmesh/2019-01-25/examples-1.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/paginators.json > models/apis/appmesh/2019-01-25/paginators-1.json
 ```
 
 Generate the SDK:
@@ -46,10 +46,10 @@ cd aws-sdk-js
 Download the JSON files, replacing the appropriate files in the SDK:
 
 ```bash
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/api.json > apis/appmesh-2019-01-25.min.json
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/api.normal.json > apis/appmesh-2019-01-25.normal.json
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/examples.json > apis/appmesh-2019-01-25.examples.json
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/paginators.json > apis/appmesh-2019-01-25.paginators.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/api.json > apis/appmesh-2019-01-25.min.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/api.normal.json > apis/appmesh-2019-01-25.normal.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/examples.json > apis/appmesh-2019-01-25.examples.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/paginators.json > apis/appmesh-2019-01-25.paginators.json
 ```
 
 Generate the SDK:
@@ -70,10 +70,10 @@ cd aws-sdk-ruby
 Download the JSON files, replacing the appropriate files in the SDK:
 
 ```bash
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/api.json > apis/appmesh/2019-01-25/api-2.json
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/docs.json > apis/appmesh/2019-01-25/docs-2.json
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/examples.json > apis/appmesh/2019-01-25/examples-1.json
-curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/sdk/paginators.json > apis/appmesh/2019-01-25/paginators-1.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/api.json > apis/appmesh/2019-01-25/api-2.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/docs.json > apis/appmesh/2019-01-25/docs-2.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/examples.json > apis/appmesh/2019-01-25/examples-1.json
+curl -s https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/sdk/paginators.json > apis/appmesh/2019-01-25/paginators-1.json
 ```
 
 Generate the SDK:


### PR DESCRIPTION
*Issue #, if available:*
Build SDK fails with following error
```
go generate ./service
unable to backfill auth-type for GetId, already set, noneunable to backfill auth-type for GetOpenIdToken, already set, noneunable to backfill auth-type for UnlinkIdentity, already set, noneunable to backfill auth-type for GetCredentialsForIdentity, already set, nonefailed to load API models failed to load API, ../models/apis/appmesh/2019-01-25/api-2.json, model load failed, ../models/apis/appmesh/2019-01-25, failed to decode ../models/apis/appmesh/2019-01-25/api-2.json, err: json: cannot unmarshal number into Go value of type api.API
exit status 1
service/generate.go:4: running "go": exit status 1
make: *** [gen-services] Error 1
```

*Description of changes:*
Fixed URL used to download model files for the sdk 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
