### PR TITLE
Update Readme instructions to download preview models

### DIFF
--- a/appmesh-preview/README.md
+++ b/appmesh-preview/README.md
@@ -2,15 +2,16 @@
 
 ## How do I use this?
 
-The easiest way to use this cli model is to load it directly from GitHub, using the following command
+If you are using [AWS CLI v1](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv1.html), you can use the cli model by loading it directly from GitHub, using the following command
 
 ```
 aws configure add-model \
     --service-name appmesh-preview \
-    --service-model https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/master/appmesh-preview/service-model.json
+    --service-model https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/service-model.json
 ```
 
-You can also check out this repository locally, and load the file using the following command
+
+If you are using [AWS CLI v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html), check out this repository locally, and load the file using the following command
 
 ```
 aws configure add-model \


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

1. Based on https://github.com/aws/aws-cli/issues/5246, AWS CLI V2 does not support setting up models by downloading directly from Github. 

Error:

```
aws configure add-model \                          *[mainline]
    --service-name appmesh-preview \
    --service-model https://raw.githubusercontent.com/aws/aws-app-mesh-roadmap/main/appmesh-preview/service-model.json

Expecting value: line 1 column 1 (char 0)
```

2. branch should be `main` not `master`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
